### PR TITLE
Prevent systemd to enter into emergency mode on mount error

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -84,5 +84,7 @@ func main() {
 	if len(args) > 0 {
 		command = strings.Join(args, " ")
 	}
-	os.Exit(m.Run(command))
+	
+	ret, _ := m.Run(command)
+	os.Exit(ret)
 }

--- a/machine.go
+++ b/machine.go
@@ -64,6 +64,12 @@ func NewMachine() (m *Machine) {
 	return
 }
 
+func InMachine() (ret bool) {
+	_, ret = os.LookupEnv("IN_FAKE_MACHINE")
+
+	return
+}
+
 func charsToString(in []int8) string {
 	s := make([]byte, len(in))
 
@@ -122,7 +128,7 @@ Requires=systemd-networkd-wait-online.service
 After=systemd-networkd-wait-online.service
 
 [Service]
-Environment=HOME=/root
+Environment=HOME=/root IN_FAKE_MACHINE=yes
 WorkingDirectory=-/scratch
 ExecStart=/wrapper
 ExecStopPost=/bin/sync

--- a/machine.go
+++ b/machine.go
@@ -71,6 +71,11 @@ func InMachine() (ret bool) {
 	return
 }
 
+func Supported() bool {
+  _, err := os.Stat("/dev/kvm")
+  return err == nil
+}
+
 func charsToString(in []int8) string {
 	s := make([]byte, len(in))
 

--- a/machine.go
+++ b/machine.go
@@ -148,6 +148,15 @@ IgnoreSIGPIPE=no
 SendSIGHUP=yes
 `
 
+const localfs = `
+[Unit]
+Description=Local File Systems
+Documentation=man:systemd.special(7)
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=local-fs-pre.target
+`
+
 func (m *Machine) addStaticVolume(directory, label string) {
 	m.mounts = append(m.mounts, mountPoint{directory, directory, label})
 }
@@ -375,6 +384,8 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	w.WriteFile("etc/systemd/system/serial-getty@ttyS0.service",
 		serviceTemplate, 0755)
+
+	w.WriteFile("/etc/systemd/system/local-fs.target", localfs, 0755)
 
 	w.WriteFile("/wrapper",
 		fmt.Sprintf(commandWrapper, command), 0755)

--- a/machine.go
+++ b/machine.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -441,7 +442,13 @@ func (m *Machine) RunInMachineWithArgs(args []string) int {
 	// FIXME: shell escaping?
 	command := strings.Join(append([]string{name}, args...), " ")
 
-	return m.startup(command, [][2]string{{os.Args[0], name}})
+	executable, err := exec.LookPath(os.Args[0])
+
+	if err != nil {
+		log.Fatalf("Failed to find executable: %v\n", err)
+	}
+
+	return m.startup(command, [][2]string{{executable, name}})
 }
 
 // RunInMachine runs the caller binary inside the fakemachine with the same

--- a/machine_test.go
+++ b/machine_test.go
@@ -64,3 +64,19 @@ fi
 		t.Fatalf("Test for tmpfs mount on scratch failed with %d", exitcode)
 	}
 }
+
+func TestSpawnMachine(t *testing.T) {
+
+	if InMachine() {
+		t.Log("Running in the machine")
+		return
+	}
+
+	m := NewMachine()
+
+	exitcode := m.RunInMachineWithArgs([]string{"-test.run TestSpawnMachine"})
+
+	if exitcode != 0 {
+		t.Fatalf("Test for respawning in the machine failed failed with %d", exitcode)
+	}
+}


### PR DESCRIPTION
Add custom `local-fs.target` to prevent systemd to fall into
emergency mode in case of mount problems.
Removed option 'OnFailure=emergency.target' from custom version of
unit-file.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>