### PR TITLE
Run go-debos on ubuntu

### DIFF
--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -109,7 +109,7 @@ func (w *WriterHelper) CopyTree(path string) {
 		} else if info.Mode().IsRegular() {
 			w.CopyFile(p)
 		} else {
-			panic("No handled")
+			log.Printf("Ignored link: %s/%s", path, p);
 		}
 
 		return nil

--- a/machine.go
+++ b/machine.go
@@ -3,6 +3,7 @@ package fakemachine
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -323,8 +324,13 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 		if mergedUsrSystem() {
 			usrpath = "/usr/lib/modules"
 		}
-		if err := w.CopyFile(path.Join(usrpath, kernelRelease, v)); err != nil {
-			return err
+		log.Printf("Getting module from host %s", v)
+		if (!strings.HasPrefix(v, "kernel/drivers/virtio")) {
+			if err := w.CopyFile(path.Join(usrpath, kernelRelease, v)); err != nil {
+				return err
+			}
+		} else {
+			log.Printf("Ignoring %s", v)
 		}
 	}
 	return nil


### PR DESCRIPTION
A couple patches are needed to run go-debos on ubuntu.
It is also needed to make the kernel user readable. `chmod go+r /boot/kernel`
