### PR TITLE
Skip double adding of already mapped directories from host

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -168,6 +168,12 @@ func (m *Machine) addStaticVolume(directory, label string) {
 // fake machine
 func (m *Machine) AddVolumeAt(hostDirectory, machineDirectory string) {
 	label := fmt.Sprintf("virtfs-%d", m.count)
+	for _, mount := range m.mounts {
+		if mount.hostDirectory == hostDirectory && mount.machineDirectory == machineDirectory {
+			// Do not need to add already existing mount
+			return
+		}
+	}
 	m.mounts = append(m.mounts, mountPoint{hostDirectory, machineDirectory, label})
 	m.count = m.count + 1
 }


### PR DESCRIPTION
Check if host's directory is already mapped to fake machine internal directory.
This allows to avoid unnecessary virtual filesystem mappings.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>