### PR TITLE
Improve error display in fakemachine CLI utility

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -84,7 +84,7 @@ func main() {
 	if options.ScratchSize != "" {
 		size, err := units.FromHumanSize(options.ScratchSize)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Couldn't parse scratch size: %v", err)
+			fmt.Fprintf(os.Stderr, "fakemachine: Couldn't parse scratch size: %v\n", err)
 			os.Exit(1)
 		}
 		m.SetScratch(size, "")

--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -103,6 +103,9 @@ func main() {
 		command = strings.Join(args, " ")
 	}
 
-	ret, _ := m.Run(command)
+	ret, err := m.Run(command)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fakemachine: %v\n", err)
+	}
 	os.Exit(ret)
 }


### PR DESCRIPTION
Print "fakemachine: Whatever error\n" if Run() fails.

Print "fakemachine: Whatever error\n" instead of just "Whatever error" if `-s` can't be parsed.

Fixes #22