### PR TITLE
main: Clarify the units used for -m, -s

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -12,9 +12,9 @@ import (
 type Options struct {
 	Volumes     []string `short:"v" long:"volume" description:"volume to mount"`
 	Images      []string `short:"i" long:"image" description:"image to add"`
-	Memory      int      `short:"m" long:"memory" description:"Amount of memory for the fakemachine"`
+	Memory      int      `short:"m" long:"memory" description:"Amount of memory for the fakemachine in megabytes"`
 	CPUs        int      `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine"`
-	ScratchSize string   `short:"s" long:"scratchsize" description:"On disk scratchspace size, if unset memory backed scratch space is used"`
+	ScratchSize string   `short:"s" long:"scratchsize" description:"On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used"`
 }
 
 var options Options


### PR DESCRIPTION
It wasn't previously obvious that `-m` expects a bare number of megabytes, but `-s` expects a unit suffix like `4G`.