### PR TITLE
Accept Qemu options from commandline

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -15,10 +15,15 @@ type Options struct {
 	Memory      int      `short:"m" long:"memory" description:"Amount of memory for the fakemachine"`
 	CPUs        int      `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine"`
 	ScratchSize string   `short:"s" long:"scratchsize" description:"On disk scratchspace size, if unset memory backed scratch space is used"`
+	QemuOpts    []string `short:"q" long:"qemuopts" description:"Additional Qemu options"`
 }
 
 var options Options
 var parser = flags.NewParser(&options, flags.Default)
+
+func SetupQemuOpts(m *fakemachine.Machine, options Options) {
+	m.AddQemuOpts(options.QemuOpts)
+}
 
 func SetupVolumes(m *fakemachine.Machine, options Options) {
 	for _, v := range options.Volumes {
@@ -80,6 +85,7 @@ func main() {
 	m := fakemachine.NewMachine()
 	SetupVolumes(m, options)
 	SetupImages(m, options)
+	SetupQemuOpts(m,options)
 
 	if options.ScratchSize != "" {
 		size, err := units.FromHumanSize(options.ScratchSize)

--- a/machine.go
+++ b/machine.go
@@ -46,6 +46,7 @@ type Machine struct {
 	scratchpath string
 	scratchfile string
 	scratchdev  string
+	qemuopts    []string
 }
 
 // Create a new machine object
@@ -193,6 +194,11 @@ func (m *Machine) AddVolumeAt(hostDirectory, machineDirectory string) {
 // fake machine
 func (m *Machine) AddVolume(directory string) {
 	m.AddVolumeAt(directory, directory)
+}
+
+// Add Qemu display options
+func (m *Machine) AddQemuOpts(qemuopts []string) {
+	m.qemuopts = qemuopts
 }
 
 // CreateImageWithLabel creates an image file at path a given size and exposes
@@ -518,6 +524,15 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		qemuargs = append(qemuargs, "-device",
 			fmt.Sprintf("virtio-blk-pci,drive=drive-virtio-disk%d,id=virtio-disk%d,serial=%s",
 				i, i, img.label))
+	}
+
+	if m.qemuopts != nil {
+		keyval := strings.Fields(m.qemuopts[0])
+		for _, v := range keyval {
+			qemuargs = append(qemuargs, v)
+		}
+	} else {
+		qemuargs = append(qemuargs, "-nographic")
 	}
 
 	qemuargs = append(qemuargs, "-append", strings.Join(kernelargs, " "))


### PR DESCRIPTION
Accept additional Qemu options from commandline. Sample usage:

 `fakemachine --qemuopts="-display sdl,gl=on -vga virtio -serial mon:stdio"` 

Signed-off-by: Lakshmipathi.G <lakshmipathi.ganapathi@collabora.co.uk>

