### PR TITLE
machine: Only build on x86_64 Linux

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -1,3 +1,6 @@
+// +build linux
+// +build amd64
+
 package fakemachine
 
 import (


### PR DESCRIPTION
This file currently assumes x86_64 Linux, so it should not be buildable
elsewhere until #18 is fixed.