### PR TITLE
machine: Don't show boot/console messages by default

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -15,6 +15,7 @@ type Options struct {
 	Memory      int      `short:"m" long:"memory" description:"Amount of memory for the fakemachine in megabytes"`
 	CPUs        int      `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine"`
 	ScratchSize string   `short:"s" long:"scratchsize" description:"On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used"`
+	ShowBoot    bool     `long:"show-boot" description:"Show boot/console messages from the fakemachine"`
 }
 
 var options Options
@@ -78,6 +79,7 @@ func main() {
 	}
 
 	m := fakemachine.NewMachine()
+	m.SetShowBoot(options.ShowBoot)
 	SetupVolumes(m, options)
 	SetupImages(m, options)
 

--- a/machine.go
+++ b/machine.go
@@ -44,6 +44,7 @@ type Machine struct {
 	images  []image
 	memory  int
 	numcpus int
+	showBoot bool
 
 	scratchsize int64
 	scratchpath string
@@ -110,6 +111,7 @@ busybox mount -t proc proc /proc
 busybox mount -t sysfs none /sys
 
 busybox modprobe virtio_pci
+busybox modprobe virtio_console
 busybox modprobe 9pnet_virtio
 busybox modprobe 9p
 
@@ -166,6 +168,7 @@ ExecStopPost=/bin/sync
 ExecStopPost=/bin/systemctl poweroff -ff
 OnFailure=poweroff.target
 Type=idle
+TTYPath=%[1]s
 StandardInput=tty-force
 StandardOutput=inherit
 StandardError=inherit
@@ -263,6 +266,11 @@ func (m *Machine) SetNumCPUs(numcpus int) {
 	m.numcpus = numcpus
 }
 
+// SetShowBoot sets whether to show boot/console messages from the fakemachine.
+func (m *Machine) SetShowBoot(showBoot bool) {
+	m.showBoot = showBoot
+}
+
 // SetScratch sets the size and location of on-disk scratch space to allocate
 // (sparsely) for /scratch. If not set /scratch will be backed by memory. If
 // Path is "" then the working directory is used as a default storage location
@@ -327,6 +335,7 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 	}
 
 	modules := []string{
+		"kernel/drivers/char/virtio_console.ko",
 		"kernel/drivers/virtio/virtio.ko",
 		"kernel/drivers/virtio/virtio_pci.ko",
 		"kernel/net/9p/9pnet.ko",
@@ -469,8 +478,19 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	m.writerKernelModules(w)
 
+	// By default we send job output to the second virtio console,
+	// reserving /dev/ttyS0 for boot messages (which we ignore)
+	// and /dev/hvc0 for possible use by systemd as a getty
+	// (which we also ignore).
+	tty := "/dev/hvc1"
+	if m.showBoot {
+		// If we are debugging a failing boot, mix job output into
+		// the normal console messages instead, so we can see both.
+		tty = "/dev/console"
+	}
+
 	w.WriteFile("etc/systemd/system/fakemachine.service",
-		serviceTemplate, 0755)
+		fmt.Sprintf(serviceTemplate, tty), 0755)
 
 	w.WriteSymlink(
 		"/lib/systemd/system/serial-getty@ttyS0.service",
@@ -504,10 +524,39 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		"-enable-kvm",
 		"-kernel", "/boot/vmlinuz-" + kernelRelease,
 		"-initrd", InitrdPath,
-		"-nographic",
+		"-display", "none",
 		"-no-reboot"}
 	kernelargs := []string{"console=ttyS0", "quiet", "panic=-1",
 		"systemd.unit=fakemachine.service"}
+
+	if m.showBoot {
+		// Create a character device representing our stdio
+		// file descriptors, and connect the emulated serial
+		// port (which is the console device for the BIOS,
+		// Linux and systemd, and is also connected to the
+		// fakemachine script) to that device
+		qemuargs = append(qemuargs,
+			"-chardev", "stdio,id=for-ttyS0",
+			"-serial", "chardev:for-ttyS0")
+	} else {
+		qemuargs = append(qemuargs,
+			// Create the bus for virtio consoles
+			"-device", "virtio-serial",
+			// Create /dev/ttyS0 to be the VM console, but
+			// ignore anything written to it, so that it
+			// doesn't corrupt our terminal
+			"-chardev", "null,id=for-ttyS0",
+			"-serial", "chardev:for-ttyS0",
+			// Reserve /dev/hvc0 to be the system console
+			// (some versions of systemd automatically put
+			// a serial getty there) but ignore it
+			"-chardev", "null,id=for-hvc0",
+			"-device", "virtconsole,chardev=for-hvc0",
+			// Connect the fakemachine script to our stdio
+			// file descriptors
+			"-chardev", "stdio,id=for-hvc1",
+			"-device", "virtconsole,chardev=for-hvc1")
+	}
 
 	for _, point := range m.mounts {
 		qemuargs = append(qemuargs, "-virtfs",


### PR DESCRIPTION
In particular this avoids having the serial port support in the
BIOS/firmware reset the user's terminal into a weird state.

Signed-off-by: Simon McVittie <smcv@collabora.com>
Fixes: #25 
