### PR TITLE
Accept Qemu options from commandline

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -16,10 +16,15 @@ type Options struct {
 	CPUs        int      `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine"`
 	ScratchSize string   `short:"s" long:"scratchsize" description:"On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used"`
 	ShowBoot    bool     `long:"show-boot" description:"Show boot/console messages from the fakemachine"`
+	QemuOpts    []string `short:"q" long:"qemuopts" description:"Additional Qemu options"`
 }
 
 var options Options
 var parser = flags.NewParser(&options, flags.Default)
+
+func SetupQemuOpts(m *fakemachine.Machine, options Options) {
+	m.AddQemuOpts(options.QemuOpts)
+}
 
 func SetupVolumes(m *fakemachine.Machine, options Options) {
 	for _, v := range options.Volumes {
@@ -82,6 +87,7 @@ func main() {
 	m.SetShowBoot(options.ShowBoot)
 	SetupVolumes(m, options)
 	SetupImages(m, options)
+	SetupQemuOpts(m,options)
 
 	if options.ScratchSize != "" {
 		size, err := units.FromHumanSize(options.ScratchSize)

--- a/machine.go
+++ b/machine.go
@@ -39,17 +39,18 @@ type image struct {
 }
 
 type Machine struct {
-	mounts  []mountPoint
-	count   int
-	images  []image
-	memory  int
-	numcpus int
+	mounts   []mountPoint
+	count    int
+	images   []image
+	memory   int
+	numcpus  int
 	showBoot bool
 
 	scratchsize int64
 	scratchpath string
 	scratchfile string
 	scratchdev  string
+	qemuopts    []string
 }
 
 // Create a new machine object
@@ -199,6 +200,11 @@ func (m *Machine) AddVolumeAt(hostDirectory, machineDirectory string) {
 // fake machine
 func (m *Machine) AddVolume(directory string) {
 	m.AddVolumeAt(directory, directory)
+}
+
+// Add Qemu display options
+func (m *Machine) AddQemuOpts(qemuopts []string) {
+	m.qemuopts = qemuopts
 }
 
 // CreateImageWithLabel creates an image file at path a given size and exposes
@@ -565,6 +571,13 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		qemuargs = append(qemuargs, "-device",
 			fmt.Sprintf("virtio-blk-pci,drive=drive-virtio-disk%d,id=virtio-disk%d,serial=%s",
 				i, i, img.label))
+	}
+
+	if m.qemuopts != nil {
+		keyval := strings.Fields(m.qemuopts[0])
+		for _, v := range keyval {
+			qemuargs = append(qemuargs, v)
+		}
 	}
 
 	qemuargs = append(qemuargs, "-append", strings.Join(kernelargs, " "))


### PR DESCRIPTION
Pass custom qemu options while launching fakemachine.

Sample usage:
By default fakemachine starts Qemu with '-display none', we
can modify it by passing below option,

qemuopts='-display sdl,gl=es'

Signed-off-by: Lakshmipathi.G <lakshmipathi.ganapathi@collabora.co.uk>