### PR TITLE
machine.go: Add support to environment variables

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -45,6 +45,7 @@ type Machine struct {
 	memory  int
 	numcpus int
 	showBoot bool
+	Environ []string
 
 	scratchsize int64
 	scratchpath string
@@ -151,6 +152,8 @@ echo Running '%[1]s'
 echo $? > /run/fakemachine/result
 `
 
+// The line 'Environment=%[2]s' is used for environemnt variables optionally
+// configured using Machine.SetEnviron()
 const serviceTemplate = `
 [Unit]
 Description=fakemachine runner
@@ -162,6 +165,7 @@ After=basic.target systemd-resolved.service binfmt-support.service systemd-netwo
 
 [Service]
 Environment=HOME=/root IN_FAKE_MACHINE=yes
+Environment=%[2]s
 WorkingDirectory=-/scratch
 ExecStart=/wrapper
 ExecStopPost=/bin/sync
@@ -301,6 +305,10 @@ func (m *Machine) generateFstab(w *writerhelper.WriterHelper) {
 	fstab = append(fstab, "")
 
 	w.WriteFile("/etc/fstab", strings.Join(fstab, "\n"), 0755)
+}
+
+func (m *Machine) SetEnviron(environ []string) {
+	m.Environ = environ
 }
 
 func (m *Machine) kernelRelease() (string, error) {
@@ -488,9 +496,8 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		// the normal console messages instead, so we can see both.
 		tty = "/dev/console"
 	}
-
 	w.WriteFile("etc/systemd/system/fakemachine.service",
-		fmt.Sprintf(serviceTemplate, tty), 0644)
+		fmt.Sprintf(serviceTemplate, tty, strings.Join(m.Environ, " ")), 0644)
 
 	w.WriteSymlink(
 		"/lib/systemd/system/serial-getty@ttyS0.service",


### PR DESCRIPTION
Add Machine.SetEnviron() to configure environment variables that will be
used by the fakemachine runner systemd service.

Signed-off-by: Peter Senna Tschudin <peter.senna@collabora.com>