### PR TITLE
machine: Move OnFailure directive to unit section

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -162,6 +162,7 @@ Before=shutdown.target
 Requires=basic.target
 Wants=systemd-resolved.service binfmt-support.service systemd-networkd.service
 After=basic.target systemd-resolved.service binfmt-support.service systemd-networkd.service
+OnFailure=poweroff.target
 
 [Service]
 Environment=HOME=/root IN_FAKE_MACHINE=yes %[2]s
@@ -169,7 +170,6 @@ WorkingDirectory=-/scratch
 ExecStart=/wrapper
 ExecStopPost=/bin/sync
 ExecStopPost=/bin/systemctl poweroff -ff
-OnFailure=poweroff.target
 Type=idle
 TTYPath=%[1]s
 StandardInput=tty-force


### PR DESCRIPTION
The OnFailure directive is misplaced, which can be seen by running
`debos --show-boot ...`:

fakemachine systemd[1]: /etc/systemd/system/fakemachine.service:16: Unknown lvalue 'OnFailure' in section 'Service'

This commit brings it back where it belongs, under the unit section.

Signed-off-by: Arnaud Rebillout <arnaud.rebillout@collabora.com>