### PR TITLE
Increase the limit for open files

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -178,6 +178,7 @@ StandardError=inherit
 KillMode=process
 IgnoreSIGPIPE=no
 SendSIGHUP=yes
+LimitNOFILE=4096
 `
 
 func (m *Machine) addStaticVolume(directory, label string) {


### PR DESCRIPTION
Set the limit of open files to 4096 for processes inside of Qemu VM.
We have no configuration for limits and kernel's defaults are used.
This leads to different settings on different kernels, hardcoded limit
allow to avoid problems with too strict defaults.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>