### PR TITLE
machine: use Utsname/Uname from golang.org/x/sys/unix to simplify string conversion

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -39,13 +39,13 @@ type image struct {
 }
 
 type Machine struct {
-	mounts  []mountPoint
-	count   int
-	images  []image
-	memory  int
-	numcpus int
+	mounts   []mountPoint
+	count    int
+	images   []image
+	memory   int
+	numcpus  int
 	showBoot bool
-	Environ []string
+	Environ  []string
 
 	scratchsize int64
 	scratchpath string


### PR DESCRIPTION
unix.Utsname has byte array instead of int8/uint8 array members which
makes it simpler to convert them to strings.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>
