### PR TITLE
Run fakemachine on ArchLinux

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -469,11 +469,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		w.WriteDirectory("/lib", 0755)
 	}
 
-	prefix := ""
 	if mergedUsrSystem() {
-		prefix = "/usr"
+		w.CopyFile("/usr/bin/busybox")
+	} else {
+		w.CopyFile("/bin/busybox")
 	}
-	w.CopyFile(prefix + "/bin/busybox")
 
 	/* Amd64 dynamic linker */
 	w.CopyFile("/lib64/ld-linux-x86-64.so.2")

--- a/machine.go
+++ b/machine.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -25,6 +26,20 @@ func mergedUsrSystem() bool {
 	}
 
 	return false
+}
+
+// Evaluate any symbolic link, then return the path's directory. Returns an
+// absolute path. Think of it as realpath(1) + dirname(1) in bash.
+func realDir(path string) (string, error) {
+	var p string
+	var err error
+	if p, err = filepath.Abs(path); err != nil {
+		return "", err
+	}
+	if p, err = filepath.EvalSymlinks(p); err != nil {
+		return "", err
+	}
+	return filepath.Dir(p), nil
 }
 
 type mountPoint struct {
@@ -458,12 +473,18 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	if mergedUsrSystem() {
 		prefix = "/usr"
 	}
-	w.CopyFile(prefix + "/lib/x86_64-linux-gnu/libresolv.so.2")
-	w.CopyFile(prefix + "/lib/x86_64-linux-gnu/libc.so.6")
 	w.CopyFile(prefix + "/bin/busybox")
 
 	/* Amd64 dynamic linker */
 	w.CopyFile("/lib64/ld-linux-x86-64.so.2")
+
+	/* C libraries */
+	libraryDir, err := realDir("/lib64/ld-linux-x86-64.so.2")
+	if err != nil {
+		return -1, err
+	}
+	w.CopyFile(libraryDir + "/libc.so.6")
+	w.CopyFile(libraryDir + "/libresolv.so.2")
 
 	w.WriteCharDevice("/dev/console", 5, 1, 0700)
 


### PR DESCRIPTION
This merge request allows fakemachine to run on ArchLinux.

Most of the changes are about finding files in different locations on the host, in order to create the initrd.