### PR TITLE
Formatting and a bug

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -31,7 +31,7 @@ func SetupVolumes(m *fakemachine.Machine, options Options) {
 		case 2:
 			m.AddVolumeAt(parts[0], parts[1])
 		default:
-			fmt.Fprintln(os.Stderr, "Failed to parse volume: %s", v)
+			fmt.Fprintln(os.Stderr, "Failed to parse volume:", v)
 			os.Exit(1)
 		}
 	}

--- a/machine.go
+++ b/machine.go
@@ -39,13 +39,13 @@ type image struct {
 }
 
 type Machine struct {
-	mounts  []mountPoint
-	count   int
-	images  []image
-	memory  int
-	numcpus int
+	mounts   []mountPoint
+	count    int
+	images   []image
+	memory   int
+	numcpus  int
 	showBoot bool
-	Environ []string
+	Environ  []string
 
 	scratchsize int64
 	scratchpath string


### PR DESCRIPTION
While adding a feature, I came across a small section of code that hadn't been run through `gofmt` and a bug that resulted in a spurious " %s" in an error message.  This patch fixes these issues.