### PR TITLE
Improve modules support

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -363,12 +363,13 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 		"modules.builtin.bin",
 		"modules.devname"}
 
+	moddir := "/lib/modules"
+	if mergedUsrSystem() {
+		moddir = "/usr/lib/modules"
+	}
+
 	for _, v := range modules {
-		usrpath := "/lib/modules"
-		if mergedUsrSystem() {
-			usrpath = "/usr/lib/modules"
-		}
-		if err := w.CopyFile(path.Join(usrpath, kernelRelease, v)); err != nil {
+		if err := w.CopyFile(path.Join(moddir, kernelRelease, v)); err != nil {
 			return err
 		}
 	}

--- a/machine.go
+++ b/machine.go
@@ -369,7 +369,9 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 	}
 
 	for _, v := range modules {
-		if err := w.CopyFile(path.Join(moddir, kernelRelease, v)); err != nil {
+		modpath := path.Join(moddir, kernelRelease, v)
+
+		if err := w.CopyFile(modpath); err != nil {
 			return err
 		}
 	}

--- a/machine.go
+++ b/machine.go
@@ -394,6 +394,15 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 
 		modpath := path.Join(moddir, kernelRelease, v)
 
+		if strings.HasSuffix(modpath, ".ko") {
+			if _, err := os.Stat(modpath); err != nil {
+				modpath += ".xz"
+			}
+			if _, err := os.Stat(modpath); err != nil {
+				return err
+			}
+		}
+
 		if err := w.CopyFile(modpath); err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request is a rework of https://github.com/go-debos/fakemachine/pull/36, hence deprecates it.

It brings two additions in the way fakemachine handles kernel module:
1. Support the file `modules.builtin` (if present), so that when some of the modules that fakemachine needs are built in the kernel, fakemachine doesn't fail trying to copy it. This is needed in latest version of Ubuntu and ArchLinux, where the `virtio` modules are now builtin.
2. Support for xz-compressed modules. This is needed for ArchLinux.