### PR TITLE
Don’t attempt to copy built-in modules

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -352,12 +352,13 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 		"modules.builtin.bin",
 		"modules.devname"}
 
+	moddir := "/lib/modules"
+	if mergedUsrSystem() {
+		moddir = "/usr/lib/modules"
+	}
+
 	for _, v := range modules {
-		usrpath := "/lib/modules"
-		if mergedUsrSystem() {
-			usrpath = "/usr/lib/modules"
-		}
-		if err := w.CopyFile(path.Join(usrpath, kernelRelease, v)); err != nil {
+		if err := w.CopyFile(path.Join(moddir, kernelRelease, v)); err != nil {
 			return err
 		}
 	}

--- a/machine.go
+++ b/machine.go
@@ -360,6 +360,15 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 	for _, v := range modules {
 		modpath := path.Join(moddir, kernelRelease, v)
 
+		if strings.HasSuffix(modpath, ".ko") {
+			if _, err := os.Stat(modpath); err != nil {
+				modpath += ".xz"
+			}
+			if _, err := os.Stat(modpath); err != nil {
+				return err
+			}
+		}
+
 		if err := w.CopyFile(modpath); err != nil {
 			return err
 		}

--- a/machine.go
+++ b/machine.go
@@ -358,7 +358,9 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper) error {
 	}
 
 	for _, v := range modules {
-		if err := w.CopyFile(path.Join(moddir, kernelRelease, v)); err != nil {
+		modpath := path.Join(moddir, kernelRelease, v)
+
+		if err := w.CopyFile(modpath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Several distributions (including Ubuntu) ship some of the modules we rely on compiled into the kernel. Since these modules are listed in `modules.builtin`, it’s very easy to detect and skip them.

Signed-off-by: Andrej Shadura <andrew.shadura@collabora.co.uk>