### PR TITLE
machine: expand $PATH with /sbin and /usr/sbin

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -434,6 +434,8 @@ func (m *Machine) cleanup() {
 func (m *Machine) startup(command string, extracontent [][2]string) (int, error) {
 	defer m.cleanup()
 
+	os.Setenv("PATH", os.Getenv("PATH") + ":/sbin:/usr/sbin")
+
 	tmpdir, err := ioutil.TempDir("", "fakemachine-")
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
Some of the commands used (e.g mkfs.ext4) are normally located under /sbin. It's 
not typical for unprivileged users to have /sbin in their $PATH so fakemachine
should add /sbin:/usr/sbin to the $PATH.

Resolves: #21

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>