### PR TITLE
machine: Abstract the KVM-specific implementation details into seperate Backend interface

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -40,6 +40,9 @@ type backend interface {
 	// not supported then the error contains a user-facing reason
 	Supported() (bool, error)
 
+	// The path to the kernel and modules
+	KernelPath() (kernelPath string, moddir string, err error)
+
 	// Start an instance of the backend
 	Start() (bool, error)
 }

--- a/backend.go
+++ b/backend.go
@@ -49,6 +49,9 @@ type backend interface {
 	// The match expression used for the networkd configuration
 	NetworkdMatch() string
 
+	// The tty used for the job output
+	JobOutputTTY() string
+
 	// Start an instance of the backend
 	Start() (bool, error)
 }

--- a/backend.go
+++ b/backend.go
@@ -43,6 +43,9 @@ type backend interface {
 	// The path to the kernel and modules
 	KernelPath() (kernelPath string, moddir string, err error)
 
+	// A list of modules to include in the initrd
+	InitrdModules() []string
+
 	// Start an instance of the backend
 	Start() (bool, error)
 }

--- a/backend.go
+++ b/backend.go
@@ -39,4 +39,7 @@ type backend interface {
 	// Whether the backend is supported on this machine; if the backend is
 	// not supported then the error contains a user-facing reason
 	Supported() (bool, error)
+
+	// Start an instance of the backend
+	Start() (bool, error)
 }

--- a/backend.go
+++ b/backend.go
@@ -58,6 +58,12 @@ type backend interface {
 	// The parameters used to mount a specific volume into the machine
 	MountParameters(mount mountPoint) (fstype string, options []string)
 
+	// A list of modules which should be probed in the initscript
+	InitModules() []string
+
+	// A list of additional volumes which should mounted in the initscript
+	InitStaticVolumes() []mountPoint
+
 	// Start an instance of the backend
 	Start() (bool, error)
 }

--- a/backend.go
+++ b/backend.go
@@ -55,6 +55,9 @@ type backend interface {
 	// The tty used for the job output
 	JobOutputTTY() string
 
+	// The parameters used to mount a specific volume into the machine
+	MountParameters(mount mountPoint) (fstype string, options []string)
+
 	// Start an instance of the backend
 	Start() (bool, error)
 }

--- a/backend.go
+++ b/backend.go
@@ -46,6 +46,9 @@ type backend interface {
 	// A list of modules to include in the initrd
 	InitrdModules() []string
 
+	// A list of udev rules
+	UdevRules() []string
+
 	// The match expression used for the networkd configuration
 	NetworkdMatch() string
 

--- a/backend.go
+++ b/backend.go
@@ -1,0 +1,42 @@
+// +build linux
+// +build amd64
+
+package fakemachine
+
+import(
+	"fmt"
+)
+
+// A list of backends which are implemented
+func BackendNames() []string {
+	return []string{"auto", "kvm"}
+}
+
+func newBackend(name string, m *Machine) (backend, error) {
+	var b backend
+
+	switch name {
+	case "auto":
+		fallthrough
+	case "kvm":
+		b = newKvmBackend(m)
+	default:
+		return nil, fmt.Errorf("%s backend does not exist", name)
+	}
+
+	// check backend is supported
+	if supported, err := b.Supported(); !supported {
+		return nil, fmt.Errorf("%s backend not supported: %v", name, err)
+	}
+
+	return b, nil
+}
+
+type backend interface {
+	// The name of the backend
+	Name() string
+
+	// Whether the backend is supported on this machine; if the backend is
+	// not supported then the error contains a user-facing reason
+	Supported() (bool, error)
+}

--- a/backend.go
+++ b/backend.go
@@ -46,6 +46,9 @@ type backend interface {
 	// A list of modules to include in the initrd
 	InitrdModules() []string
 
+	// The match expression used for the networkd configuration
+	NetworkdMatch() string
+
 	// Start an instance of the backend
 	Start() (bool, error)
 }

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -98,6 +98,17 @@ func (b kvmBackend) KernelPath() (string, string, error) {
 	return kernelPath, moddir, nil
 }
 
+func (b kvmBackend) InitrdModules() []string {
+	return []string{"kernel/drivers/char/virtio_console.ko",
+			"kernel/drivers/virtio/virtio.ko",
+			"kernel/drivers/virtio/virtio_pci.ko",
+			"kernel/net/9p/9pnet.ko",
+			"kernel/drivers/virtio/virtio_ring.ko",
+			"kernel/fs/9p/9p.ko",
+			"kernel/net/9p/9pnet_virtio.ko",
+			"kernel/fs/fscache/fscache.ko"}
+}
+
 func (b kvmBackend) Start() (bool, error) {
 	m := b.machine
 

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -1,0 +1,27 @@
+// +build linux
+// +build amd64
+
+package fakemachine
+
+import (
+	"os"
+)
+
+type kvmBackend struct {
+	machine *Machine
+}
+
+func newKvmBackend(m *Machine) kvmBackend {
+	return kvmBackend{machine: m}
+}
+
+func (b kvmBackend) Name() string {
+	return "kvm"
+}
+
+func (b kvmBackend) Supported() (bool, error) {
+	if _, err := os.Stat("/dev/kvm"); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -143,6 +143,14 @@ func (b kvmBackend) MountParameters(mount mountPoint) (string, []string) {
 	return "9p", []string{"trans=virtio", "version=9p2000.L", "cache=loose", "msize=262144"}
 }
 
+func (b kvmBackend) InitModules() []string {
+	return []string{"virtio_pci", "virtio_console", "9pnet_virtio", "9p"}
+}
+
+func (b kvmBackend) InitStaticVolumes() []mountPoint {
+	return []mountPoint{}
+}
+
 func (b kvmBackend) Start() (bool, error) {
 	m := b.machine
 

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -139,6 +139,10 @@ func (b kvmBackend) JobOutputTTY() string {
 	return "/dev/hvc0"
 }
 
+func (b kvmBackend) MountParameters(mount mountPoint) (string, []string) {
+	return "9p", []string{"trans=virtio", "version=9p2000.L", "cache=loose", "msize=262144"}
+}
+
 func (b kvmBackend) Start() (bool, error) {
 	m := b.machine
 

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -109,6 +109,10 @@ func (b kvmBackend) InitrdModules() []string {
 			"kernel/fs/fscache/fscache.ko"}
 }
 
+func (b kvmBackend) NetworkdMatch() string {
+	return "e*"
+}
+
 func (b kvmBackend) Start() (bool, error) {
 	m := b.machine
 

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -113,6 +113,19 @@ func (b kvmBackend) NetworkdMatch() string {
 	return "e*"
 }
 
+func (b kvmBackend) JobOutputTTY() string {
+	// By default we send job output to the second virtio console,
+	// reserving /dev/ttyS0 for boot messages (which we ignore)
+	// and /dev/hvc0 for possible use by systemd as a getty
+	// (which we also ignore).
+	// If we are debugging, mix job output into the normal
+	// console messages instead, so we can see both.
+	if b.machine.showBoot {
+		return "/dev/console"
+	}
+	return "/dev/hvc0"
+}
+
 func (b kvmBackend) Start() (bool, error) {
 	m := b.machine
 

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -4,7 +4,10 @@
 package fakemachine
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 )
 
 type kvmBackend struct {
@@ -23,5 +26,97 @@ func (b kvmBackend) Supported() (bool, error) {
 	if _, err := os.Stat("/dev/kvm"); err != nil {
 		return false, err
 	}
+
+	if _, err := b.QemuPath(); err != nil {
+		return false, err
+	}
 	return true, nil
+}
+
+func (b kvmBackend) QemuPath() (string, error) {
+	return exec.LookPath("qemu-system-x86_64")
+}
+
+func (b kvmBackend) Start() (bool, error) {
+	m := b.machine
+
+	kernelPath, _, err := hostKernelPath()
+	if err != nil {
+		return false, err
+	}
+	memory := fmt.Sprintf("%d", m.memory)
+	numcpus := fmt.Sprintf("%d", m.numcpus)
+	qemuargs := []string{"qemu-system-x86_64",
+		"-cpu", "host",
+		"-smp", numcpus,
+		"-m", memory,
+		"-enable-kvm",
+		"-kernel", kernelPath,
+		"-initrd", m.initrdpath,
+		"-display", "none",
+		"-no-reboot"}
+	kernelargs := []string{"console=ttyS0", "panic=-1",
+		"systemd.unit=fakemachine.service"}
+
+	if m.showBoot {
+		// Create a character device representing our stdio
+		// file descriptors, and connect the emulated serial
+		// port (which is the console device for the BIOS,
+		// Linux and systemd, and is also connected to the
+		// fakemachine script) to that device
+		qemuargs = append(qemuargs,
+			"-chardev", "stdio,id=for-ttyS0,signal=off",
+			"-serial", "chardev:for-ttyS0")
+	} else {
+		qemuargs = append(qemuargs,
+			// Create the bus for virtio consoles
+			"-device", "virtio-serial",
+			// Create /dev/ttyS0 to be the VM console, but
+			// ignore anything written to it, so that it
+			// doesn't corrupt our terminal
+			"-chardev", "null,id=for-ttyS0",
+			"-serial", "chardev:for-ttyS0",
+			// Connect the fakemachine script to our stdio
+			// file descriptors
+			"-chardev", "stdio,id=for-hvc0,signal=off",
+			"-device", "virtconsole,chardev=for-hvc0")
+	}
+
+	for _, point := range m.mounts {
+		qemuargs = append(qemuargs, "-virtfs",
+			fmt.Sprintf("local,mount_tag=%s,path=%s,security_model=none",
+				point.label, point.hostDirectory))
+	}
+
+	for i, img := range m.images {
+		qemuargs = append(qemuargs, "-drive",
+			fmt.Sprintf("file=%s,if=none,format=raw,cache=unsafe,id=drive-virtio-disk%d", img.path, i))
+		qemuargs = append(qemuargs, "-device",
+			fmt.Sprintf("virtio-blk-pci,drive=drive-virtio-disk%d,id=virtio-disk%d,serial=%s",
+				i, i, img.label))
+	}
+
+	qemuargs = append(qemuargs, "-append", strings.Join(kernelargs, " "))
+
+	pa := os.ProcAttr{
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+	}
+
+	qemubin, err := b.QemuPath()
+	if err != nil {
+		return false, err
+	}
+
+	p, err := os.StartProcess(qemubin, qemuargs, &pa)
+	if err != nil {
+		return false, err
+	}
+
+	// wait for kvm process to exit
+	pstate, err := p.Wait()
+	if err != nil {
+		return false, err
+	}
+
+	return pstate.Success(), nil
 }

--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -109,6 +109,19 @@ func (b kvmBackend) InitrdModules() []string {
 			"kernel/fs/fscache/fscache.ko"}
 }
 
+func (b kvmBackend) UdevRules() []string {
+	udevRules := []string{}
+
+	// create symlink under /dev/disk/by-fakemachine-label/ for each virtual image
+	for i, img := range b.machine.images {
+		driveLetter := 'a' + i
+		udevRules = append(udevRules,
+			fmt.Sprintf(`KERNEL=="vd%c", SYMLINK+="disk/by-fakemachine-label/%s"`, driveLetter, img.label),
+			fmt.Sprintf(`KERNEL=="vd%c[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, driveLetter, img.label))
+	}
+	return udevRules
+}
+
 func (b kvmBackend) NetworkdMatch() string {
 	return "e*"
 }

--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Options struct {
+	Backend	    string   `short:"b" long:"backend" description:"Virtualisation backend to use" default:"auto"`
 	Volumes     []string `short:"v" long:"volume" description:"volume to mount"`
 	Images      []string `short:"i" long:"image" description:"image to add"`
 	Memory      int      `short:"m" long:"memory" description:"Amount of memory for the fakemachine in megabytes"`
@@ -68,6 +69,10 @@ func SetupImages(m *fakemachine.Machine, options Options) {
 }
 
 func main() {
+	// append the list of available backends to the commandline argument parser
+	opt := parser.FindOptionByLongName("backend")
+	opt.Choices = fakemachine.BackendNames()
+
 	args, err := parser.Parse()
 	if err != nil {
 		flagsErr, ok := err.(*flags.Error)
@@ -78,7 +83,12 @@ func main() {
 		}
 	}
 
-	m := fakemachine.NewMachine()
+	m, err := fakemachine.NewMachineWithBackend(options.Backend)
+	if err != nil {
+		fmt.Printf("fakemachine: %v\n", err)
+		os.Exit(1)
+	}
+
 	m.SetShowBoot(options.ShowBoot)
 	SetupVolumes(m, options)
 	SetupImages(m, options)

--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -58,11 +58,13 @@ func (w *WriterHelper) WriteDirectory(directory string, perm os.FileMode) {
 }
 
 func (w *WriterHelper) WriteFile(file, content string, perm os.FileMode) {
+	w.WriteFileRaw(file, []byte(content), perm)
+}
+
+func (w *WriterHelper) WriteFileRaw(file string, bytes []byte, perm os.FileMode) {
 	w.ensureBaseDirectory(path.Dir(file))
 
 	hdr := new(cpio.Header)
-
-	bytes := []byte(content)
 
 	hdr.Type = cpio.TYPE_REG
 	hdr.Name = file

--- a/machine.go
+++ b/machine.go
@@ -322,27 +322,23 @@ func (m *Machine) SetEnviron(environ []string) {
 	m.Environ = environ
 }
 
-func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper, moddir string) error {
-	modules := []string{
-		"kernel/drivers/char/virtio_console.ko",
-		"kernel/drivers/virtio/virtio.ko",
-		"kernel/drivers/virtio/virtio_pci.ko",
-		"kernel/net/9p/9pnet.ko",
-		"kernel/drivers/virtio/virtio_ring.ko",
-		"kernel/fs/9p/9p.ko",
-		"kernel/net/9p/9pnet_virtio.ko",
-		"kernel/fs/fscache/fscache.ko",
-		"modules.order",
-		"modules.builtin",
-		"modules.dep",
-		"modules.dep.bin",
-		"modules.alias",
-		"modules.alias.bin",
-		"modules.softdep",
-		"modules.symbols",
-		"modules.symbols.bin",
-		"modules.builtin.bin",
-		"modules.devname"}
+func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper, moddir string, modules []string) error {
+	if len(modules) == 0 {
+		return nil
+	}
+
+	modules = append(modules,
+			"modules.order",
+			"modules.builtin",
+			"modules.dep",
+			"modules.dep.bin",
+			"modules.alias",
+			"modules.alias.bin",
+			"modules.softdep",
+			"modules.symbols",
+			"modules.symbols.bin",
+			"modules.builtin.bin",
+			"modules.devname")
 
 	// build a list of built-in modules so that we don’t attempt to copy them
 	var builtinModules = make(map[string]bool)
@@ -524,7 +520,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		"/etc/resolv.conf",
 		0755)
 
-	m.writerKernelModules(w, kernelModuleDir)
+	m.writerKernelModules(w, kernelModuleDir, backend.InitrdModules())
 
 	// By default we send job output to the second virtio console,
 	// reserving /dev/ttyS0 for boot messages (which we ignore)

--- a/machine.go
+++ b/machine.go
@@ -487,6 +487,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	backend := m.backend
 
+	_, kernelModuleDir, err := hostKernelPath()
+	if err != nil {
+		return -1, err
+	}
+
 	w := writerhelper.NewWriterHelper(f)
 
 	w.WriteDirectory("/scratch", 01777)
@@ -597,72 +602,9 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	w.Close()
 	f.Close()
 
-	kernelRelease, err := m.kernelRelease()
-	if err != nil {
-		return -1, err
-	}
-	memory := fmt.Sprintf("%d", m.memory)
-	numcpus := fmt.Sprintf("%d", m.numcpus)
-	qemuargs := []string{"qemu-system-x86_64",
-		"-cpu", "host",
-		"-smp", numcpus,
-		"-m", memory,
-		"-enable-kvm",
-		"-kernel", "/boot/vmlinuz-" + kernelRelease,
-		"-initrd", m.initrdpath,
-		"-display", "none",
-		"-no-reboot"}
-	kernelargs := []string{"console=ttyS0", "panic=-1",
-		"systemd.unit=fakemachine.service"}
-
-	if m.showBoot {
-		// Create a character device representing our stdio
-		// file descriptors, and connect the emulated serial
-		// port (which is the console device for the BIOS,
-		// Linux and systemd, and is also connected to the
-		// fakemachine script) to that device
-		qemuargs = append(qemuargs,
-			"-chardev", "stdio,id=for-ttyS0,signal=off",
-			"-serial", "chardev:for-ttyS0")
-	} else {
-		qemuargs = append(qemuargs,
-			// Create the bus for virtio consoles
-			"-device", "virtio-serial",
-			// Create /dev/ttyS0 to be the VM console, but
-			// ignore anything written to it, so that it
-			// doesn't corrupt our terminal
-			"-chardev", "null,id=for-ttyS0",
-			"-serial", "chardev:for-ttyS0",
-			// Connect the fakemachine script to our stdio
-			// file descriptors
-			"-chardev", "stdio,id=for-hvc0,signal=off",
-			"-device", "virtconsole,chardev=for-hvc0")
-	}
-
-	for _, point := range m.mounts {
-		qemuargs = append(qemuargs, "-virtfs",
-			fmt.Sprintf("local,mount_tag=%s,path=%s,security_model=none",
-				point.label, point.hostDirectory))
-	}
-
-	for i, img := range m.images {
-		qemuargs = append(qemuargs, "-drive",
-			fmt.Sprintf("file=%s,if=none,format=raw,cache=unsafe,id=drive-virtio-disk%d", img.path, i))
-		qemuargs = append(qemuargs, "-device",
-			fmt.Sprintf("virtio-blk-pci,drive=drive-virtio-disk%d,id=virtio-disk%d,serial=%s",
-				i, i, img.label))
-	}
-
-	qemuargs = append(qemuargs, "-append", strings.Join(kernelargs, " "))
-
-	pa := os.ProcAttr{
-		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
-	}
-
-	if p, err := os.StartProcess("/usr/bin/qemu-system-x86_64", qemuargs, &pa); err != nil {
-		return -1, err
-	} else {
-		p.Wait()
+	success, err := backend.Start()
+	if !success || err != nil {
+		return -1, fmt.Errorf("error starting %s backend: %v", backend.Name(), err)
 	}
 
 	result, err := os.Open(path.Join(tmpdir, "result"))

--- a/machine.go
+++ b/machine.go
@@ -523,18 +523,8 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	m.writerKernelModules(w, kernelModuleDir, backend.InitrdModules())
 
-	// By default we send job output to the second virtio console,
-	// reserving /dev/ttyS0 for boot messages (which we ignore)
-	// and /dev/hvc0 for possible use by systemd as a getty
-	// (which we also ignore).
-	tty := "/dev/hvc0"
-	if m.showBoot {
-		// If we are debugging a failing boot, mix job output into
-		// the normal console messages instead, so we can see both.
-		tty = "/dev/console"
-	}
 	w.WriteFile("etc/systemd/system/fakemachine.service",
-		fmt.Sprintf(serviceTemplate, tty, strings.Join(m.Environ, " ")), 0644)
+		fmt.Sprintf(serviceTemplate, backend.JobOutputTTY(), strings.Join(m.Environ, " ")), 0644)
 
 	w.WriteSymlink(
 		"/lib/systemd/system/serial-getty@ttyS0.service",

--- a/machine.go
+++ b/machine.go
@@ -135,9 +135,9 @@ if ! busybox test -L /bin ; then
 fi
 exec /lib/systemd/systemd
 `
-const networkd = `
+const networkdTemplate = `
 [Match]
-Name=e*
+Name=%[1]s
 
 [Network]
 DHCP=ipv4
@@ -514,7 +514,8 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		w.WriteFile("/etc/udev/rules.d/61-fakemachine.rules", strings.Join(udevRules, "\n"), 0444)
 	}
 
-	w.WriteFile("/etc/systemd/network/ethernet.network", networkd, 0444)
+	w.WriteFile("/etc/systemd/network/ethernet.network",
+		fmt.Sprintf(networkdTemplate, backend.NetworkdMatch()), 0444)
 	w.WriteSymlink(
 		"/lib/systemd/resolv.conf",
 		"/etc/resolv.conf",

--- a/machine.go
+++ b/machine.go
@@ -241,7 +241,7 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (s
 	i.Close()
 	m.images = append(m.images, image{path, label})
 
-	return fmt.Sprintf("/dev/disk/by-id/virtio-%s", label), nil
+	return fmt.Sprintf("/dev/disk/by-fakemachine-label/%s", label), nil
 }
 
 // CreateImage does the same as CreateImageWithLabel but lets the library pick
@@ -522,6 +522,19 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	w.CopyFile("/etc/passwd")
 	w.CopyFile("/etc/group")
 	w.CopyFile("/etc/nsswitch.conf")
+
+	// udev rule to create symlink under /dev/disk/by-fakemachine-label/ for each virtual image
+	if len(m.images) > 0 {
+		udevRules := []string{}
+		for i, img := range m.images {
+			driveLetter := 'a' + i
+			udevRules = append(udevRules,
+				fmt.Sprintf(`KERNEL=="vd%c", SYMLINK+="disk/by-fakemachine-label/%s"`, driveLetter, img.label),
+				fmt.Sprintf(`KERNEL=="vd%c[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, driveLetter, img.label))
+		}
+		udevRules = append(udevRules, "")
+		w.WriteFile("/etc/udev/rules.d/61-fakemachine.rules", strings.Join(udevRules, "\n"), 0444)
+	}
 
 	w.WriteFile("/etc/systemd/network/ethernet.network", networkd, 0444)
 	w.WriteSymlink(

--- a/machine.go
+++ b/machine.go
@@ -501,18 +501,9 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	w.CopyFile("/etc/group")
 	w.CopyFile("/etc/nsswitch.conf")
 
-	// udev rule to create symlink under /dev/disk/by-fakemachine-label/ for each virtual image
-	if len(m.images) > 0 {
-		udevRules := []string{}
-		for i, img := range m.images {
-			driveLetter := 'a' + i
-			udevRules = append(udevRules,
-				fmt.Sprintf(`KERNEL=="vd%c", SYMLINK+="disk/by-fakemachine-label/%s"`, driveLetter, img.label),
-				fmt.Sprintf(`KERNEL=="vd%c[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, driveLetter, img.label))
-		}
-		udevRules = append(udevRules, "")
-		w.WriteFile("/etc/udev/rules.d/61-fakemachine.rules", strings.Join(udevRules, "\n"), 0444)
-	}
+	// udev rules
+	udevRules := strings.Join(backend.UdevRules(), "\n") + "\n"
+	w.WriteFile("/etc/udev/rules.d/61-fakemachine.rules", udevRules, 0444)
 
 	w.WriteFile("/etc/systemd/network/ethernet.network",
 		fmt.Sprintf(networkdTemplate, backend.NetworkdMatch()), 0444)

--- a/machine.go
+++ b/machine.go
@@ -54,6 +54,7 @@ type Machine struct {
 	scratchpath string
 	scratchfile string
 	scratchdev  string
+	initrdpath  string
 }
 
 // Create a new machine object with the auto backend
@@ -477,8 +478,8 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		return -1, err
 	}
 
-	InitrdPath := path.Join(tmpdir, "initramfs.cpio")
-	f, err := os.OpenFile(InitrdPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	m.initrdpath = path.Join(tmpdir, "initramfs.cpio")
+	f, err := os.OpenFile(m.initrdpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 
 	if err != nil {
 		return -1, err
@@ -608,7 +609,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		"-m", memory,
 		"-enable-kvm",
 		"-kernel", "/boot/vmlinuz-" + kernelRelease,
-		"-initrd", InitrdPath,
+		"-initrd", m.initrdpath,
 		"-display", "none",
 		"-no-reboot"}
 	kernelargs := []string{"console=ttyS0", "panic=-1",


### PR DESCRIPTION
This MR defines the base for UML support for fakemachine.

End-user functionality wise no changes have been introduced with this MR; I have abstracted the machine specific implementation detail of the machine setup into its own interface and provided an implementation for KVM.