### PR TITLE
kvm: Check /dev/kvm permissions are correct early

### DIFF
--- a/backend_kvm.go
+++ b/backend_kvm.go
@@ -28,9 +28,11 @@ func (b kvmBackend) Name() string {
 }
 
 func (b kvmBackend) Supported() (bool, error) {
-	if _, err := os.Stat("/dev/kvm"); err != nil {
+	kvmDevice, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0);
+	if err != nil {
 		return false, err
 	}
+	kvmDevice.Close()
 
 	if _, err := b.QemuPath(); err != nil {
 		return false, err


### PR DESCRIPTION
Currently fakemachine checks whether /dev/kvm exists to see if the
backend is supported, if the device exists but the permissions are
incorrect (i.e running as a user without acces) then fakemachine
still returns that kvm is supported but fails later with a really
unhelpful error:

    $ fakemachine --backend=kvm
    Could not access KVM kernel module: Permission denied
    qemu-system-x86_64: failed to initialize kvm: Permission denied
    error starting kvm backend: <nil>

So when checking if the kvm backend is suppored, as well as checking
if /dev/kvm exists, let's also check whether the permissions are
correct and if not, stop with an error earlier:

    $ fakemachine --backend=kvm
    fakemachine: kvm backend not supported: open /dev/kvm: permission denied

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>