### PR TITLE
machine: copy /etc/hosts in fakemachine

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -549,6 +549,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	w.CopyFile("/etc/passwd")
 	w.CopyFile("/etc/group")
 	w.CopyFile("/etc/nsswitch.conf")
+	w.CopyFile("/etc/hosts")
 
 	// udev rules
 	udevRules := strings.Join(backend.UdevRules(), "\n") + "\n"


### PR DESCRIPTION
sometimes when debootstrap uses custom repository to resolve its host to ip
 it requires an '/etc/hosts' file with its host to ip mapping in fakemachine
 assuming host machine '/etc/hosts' has this mapping, copy this file to fakemachine
 should work.

Signed-off-by: venkata pyla <venkata.pyla@toshiba-tsip.com>