### PR TITLE
Simplify panic

### DIFF
--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -125,7 +125,6 @@ func (w *WriterHelper) CopyFileTo(src, dst string) error {
 	f, err := os.Open(src)
 	if err != nil {
 		panic(err)
-		return err
 	}
 	defer f.Close()
 

--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -2,7 +2,6 @@ package writerhelper
 
 import (
 	"io"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -125,7 +124,7 @@ func (w *WriterHelper) CopyFileTo(src, dst string) error {
 
 	f, err := os.Open(src)
 	if err != nil {
-		log.Panicf("open failed: %s - %v", src, err)
+		panic(err)
 		return err
 	}
 	defer f.Close()


### PR DESCRIPTION
Hello,

This PR simplifies the panic and its output if `CopyFileTo()` cannot open a file.

The former version outputs the following message:

```
panic: open failed: /usr/lib/modules/5.13.13-arch1-1/kernel/drivers/char/virtio_console.ko - open /usr/lib/modules/5.13.13-arch1-1/kernel/drivers/char/virtio_console.ko: no such file or directory
```

While the new version outputs the message below:

```
panic: open /usr/lib/modules/5.13.13-arch`panic()`1-1/kernel/drivers/char/virtio_console.ko: no such file or directory
```

The output does not use a formatted string, therefore the package `log` is not needed anymore and is removed.

Also, the subsequent `return err` is removed as it is never reached as panic'ing stops the execution of the coroutine.

Best Regards,
Gaël