### PR TITLE
backend: remove InitrdModules() in favour of InitModules()

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -72,9 +72,6 @@ type backend interface {
 	// The path to the modules
 	ModulePath() (moddir string, err error)
 
-	// A list of modules to include in the initrd
-	InitrdModules() []string
-
 	// A list of udev rules
 	UdevRules() []string
 
@@ -87,7 +84,7 @@ type backend interface {
 	// The parameters used to mount a specific volume into the machine
 	MountParameters(mount mountPoint) (fstype string, options []string)
 
-	// A list of modules which should be probed in the initscript
+	// A list of modules to be added to initrd and probed in the initscript
 	InitModules() []string
 
 	// A list of additional volumes which should mounted in the initscript

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -118,15 +118,6 @@ func (b qemuBackend) ModulePath() (string, error) {
 	return moddir, nil
 }
 
-func (b qemuBackend) InitrdModules() []string {
-	return []string{"virtio_console",
-			"virtio",
-			"virtio_pci",
-			"virtio_ring",
-			"9p",
-			"9pnet_virtio"}
-}
-
 func (b qemuBackend) UdevRules() []string {
 	udevRules := []string{}
 

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -82,10 +82,6 @@ func (b umlBackend) SlirpHelperPath() (string, error) {
 	return exec.LookPath("libslirp-helper")
 }
 
-func (b umlBackend) InitrdModules() []string {
-	return []string{}
-}
-
 func (b umlBackend) UdevRules() []string {
 	udevRules := []string{}
 

--- a/machine.go
+++ b/machine.go
@@ -661,7 +661,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		"/etc/resolv.conf",
 		0755)
 
-	err = m.writerKernelModules(w, kernelModuleDir, backend.InitrdModules())
+	err = m.writerKernelModules(w, kernelModuleDir, backend.InitModules())
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
With recently the former was reworked from list of modules and their
respective dependencies (all of which including relative path and
extension) to a modules that we use.

The only difference between the two is - virtio and virtio_ring. Both of
those are low level dependencies of the other virtio modules.

So just remove the extra function/array and consistently use
InitModules() across the board.


As follow-up on @santoshmahto7 's work in https://github.com/go-debos/fakemachine/pull/62