### PR TITLE
Replace Arch specific kernel copy hack with more generic solution

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -66,8 +66,11 @@ type backend interface {
 	// Get kernel release version
 	KernelRelease() (string, error)
 
-	// The path to the kernel and modules
-	KernelPath() (kernelPath string, moddir string, err error)
+	// The path to the kernel
+	KernelPath() (kernelPath string, err error)
+
+	// The path to the modules
+	ModulePath() (moddir string, err error)
 
 	// A list of modules to include in the initrd
 	InitrdModules() []string

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -71,15 +71,24 @@ func (b qemuBackend) KernelRelease() (string, error) {
 	return "", fmt.Errorf("No kernel found")
 }
 
-func (b qemuBackend) KernelPath() (string, string, error) {
+func (b qemuBackend) KernelPath() (string, error) {
 	kernelRelease, err := b.KernelRelease()
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	kernelPath := "/boot/vmlinuz-" + kernelRelease
 	if _, err := os.Stat(kernelPath); err != nil {
-		return "", "", err
+		return "", err
+	}
+
+	return kernelPath, nil
+}
+
+func (b qemuBackend) ModulePath() (string, error) {
+	kernelRelease, err := b.KernelRelease()
+	if err != nil {
+		return "", err
 	}
 
 	moddir := "/lib/modules"
@@ -89,10 +98,10 @@ func (b qemuBackend) KernelPath() (string, string, error) {
 
 	moddir = path.Join(moddir, kernelRelease)
 	if _, err := os.Stat(moddir); err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return kernelPath, moddir, nil
+	return moddir, nil
 }
 
 func (b qemuBackend) InitrdModules() []string {
@@ -153,7 +162,7 @@ func (b qemuBackend) Start() (bool, error) {
 func (b qemuBackend) StartQemu(kvm bool) (bool, error) {
 	m := b.machine
 
-	kernelPath, _, err := b.KernelPath()
+	kernelPath, err := b.KernelPath()
 	if err != nil {
 		return false, err
 	}

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -72,6 +72,20 @@ func (b qemuBackend) KernelRelease() (string, error) {
 }
 
 func (b qemuBackend) KernelPath() (string, error) {
+	/* First we look within the modules directory, as supported by
+	 * various distributions - Arch, Fedora...
+	 *
+	 * ... perhaps because systemd requires it to allow hibernation
+	 * https://github.com/systemd/systemd/commit/edda44605f06a41fb86b7ab8128dcf99161d2344
+	 */
+	if moddir, err := b.ModulePath(); err == nil {
+		kernelPath := path.Join(moddir, "vmlinuz")
+		if _, err := os.Stat(kernelPath); err == nil {
+			return kernelPath, nil
+		}
+	}
+
+	/* Fall-back to the previous method and look in /boot */
 	kernelRelease, err := b.KernelRelease()
 	if err != nil {
 		return "", err

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -72,60 +71,14 @@ func (b qemuBackend) KernelRelease() (string, error) {
 	return "", fmt.Errorf("No kernel found")
 }
 
-func (b qemuBackend) hostKernelPath(kernelRelease string) (string, error) {
-	kernelDir := "/boot"
-	kernelPrefix := "vmlinuz-"
-
-	/* First, try to find a kernel with a well-known name */
-	kernelPath := filepath.Join(kernelDir, kernelPrefix + kernelRelease)
-	if _, err := os.Stat(kernelPath); err == nil {
-		return kernelPath, nil
-	}
-
-	/* Otherwise, inspect each kernel installed, and look for the release
-	 * string straight in the binary. Not pretty, but it works. */
-	needle := kernelRelease
-	if !strings.HasSuffix(needle, " ") {
-		// Add space to match exact kernel description string e.g
-		// 4.19.0-6-amd64 (debian-kernel@lists.debian.org) #1 SMP Debian 4.19.67-2+deb10u2 (2019-11-11)
-		needle += " "
-	}
-
-	files, err := ioutil.ReadDir(kernelDir)
-	if err != nil {
-		return "", err
-	}
-
-	for _, f := range files {
-		if !strings.HasPrefix(f.Name(), kernelPrefix) || f.IsDir() {
-			continue
-		}
-
-		kernelPath := filepath.Join(kernelDir, f.Name())
-		buf, err := ioutil.ReadFile(kernelPath)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Failed to read kernel:", err)
-			continue
-		}
-
-		if !bytes.Contains(buf, []byte(needle)) {
-			continue
-		}
-
-		return kernelPath, nil
-	}
-
-	return "", fmt.Errorf("No kernel found for release %s", kernelRelease)
-}
-
 func (b qemuBackend) KernelPath() (string, string, error) {
 	kernelRelease, err := b.KernelRelease()
 	if err != nil {
 		return "", "", err
 	}
 
-	kernelPath, err := b.hostKernelPath(kernelRelease)
-	if err != nil {
+	kernelPath := "/boot/vmlinuz-" + kernelRelease
+	if _, err := os.Stat(kernelPath); err != nil {
 		return "", "", err
 	}
 

--- a/machine.go
+++ b/machine.go
@@ -552,7 +552,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	backend := m.backend
 
-	_, kernelModuleDir, err := backend.KernelPath()
+	kernelModuleDir, err := backend.ModulePath()
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
This MR reverts the Arch specific commit, splits `KernelPath()` into `KernelPath()` & `ModulePath()`, reusing the last one to implement a shorter and more common solution.

In particular: Many platforms store the kernel under `/usr/lib/modules/$uname_r/vmlinuz` - perhaps because systemd expects it, to enable hibernate.

As added bonus - there is no need for a initramdisk generator, which tends to be responsible for copying the kernel in `/boot`.

Tl:Dr: Shorter, more generic code and fewer dependencies \o/

Big shout out to @gasinvein for the original suggestion.