### PR TITLE
machine: copy only selected modules.* files

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -532,15 +532,10 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper, moddir strin
 		return nil
 	}
 
-	modfiles := []string {"modules.order",
+	modfiles := []string {
 			"modules.builtin",
 			"modules.alias",
-			"modules.alias.bin",
-			"modules.softdep",
-			"modules.symbols",
-			"modules.symbols.bin",
-			"modules.builtin.bin",
-			"modules.devname"}
+			"modules.symbols"}
 
 	for _, v := range modfiles {
 		if err := w.CopyFile(moddir + "/" + v); err != nil {


### PR DESCRIPTION
Busybox uses only the modules.{builtin,dep,alias,symbols}.

Any other files, such as the .bin ones are kmod specific, so we don't
need to bother with them.