### PR TITLE
Check mountpoints exist on the host early

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -185,3 +185,35 @@ func TestImageLabel(t *testing.T) {
 		t.Fatalf("Test for images in the machine failed failed with %d", exitcode)
 	}
 }
+
+func TestVolumes(t *testing.T) {
+	t.Parallel()
+	if InMachine() {
+		t.Log("Running in the machine")
+		return
+	}
+
+	/* Try to mount a non-existent file into the machine */
+	m := CreateMachine(t)
+	m.AddVolume("random_directory_never_exists")
+
+	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run TestVolumes"})
+	require.Equal(t, exitcode, -1)
+	require.Error(t, err)
+
+	/* Try to mount a device file into the machine */
+	m = CreateMachine(t)
+	m.AddVolume("/dev/zero")
+
+	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run TestVolumes"})
+	require.Equal(t, exitcode, -1)
+	require.Error(t, err)
+
+	/* Try to mount a volume with whitespace into the machine */
+	m = CreateMachine(t)
+	m.AddVolumeAt("/dev", "/dev ices")
+
+	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run TestVolumes"})
+	require.Equal(t, exitcode, -1)
+	require.Error(t, err)
+}


### PR DESCRIPTION
If a mountpoint doesn't exist on the host, the backend
will fail to mount it and results in an ugly error
from the backend:

    $ fakemachine -v /null
    qemu-system-x86_64: -virtfs local,mount_tag=virtfs-5,path=/null,security_model=none: cannot initialize fsdev 'virtfs-5': failed to open '/null': No such file or directory
    fakemachine: error starting kvm backend: <nil>

Check if a mountpoint exists before attempting to start
the backend.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>