### PR TITLE
backend: Add qemu to the list of backend names

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -9,7 +9,7 @@ import(
 
 // A list of backends which are implemented
 func BackendNames() []string {
-	return []string{"auto", "kvm", "uml"}
+	return []string{"auto", "kvm", "uml", "qemu"}
 }
 
 func newBackend(name string, m *Machine) (backend, error) {


### PR DESCRIPTION
Otherwise the --help screen will not print it, even though we'll accept
the value at runtime.

@sjoerdsimons was it omitted deliberately?