### PR TITLE
Some README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Creates a vm based on the currently running system.
 
   fakemachine [OPTIONS]
 
+```
 Application Options:
   -b, --backend=[auto|kvm|uml|qemu] Virtualisation backend to use (default: auto)
   -v, --volume=                     volume to mount
@@ -19,3 +20,4 @@ Application Options:
 
 Help Options:
   -h, --help                        Show this help message
+```


### PR DESCRIPTION
Github renders consecutive lines into an alinea.
The added triple backticks protect
  -v, --volume=                     volume to mount
  -i, --image=                      image to add
  -e, --environ-var=                Environment variables (use -e VARIABLE:VALUE syntax)
to become
  -v, --volume= volume to mount -i, --image= image to add -e,
  --environ-var=  Environment variables (use -e VARIABLE:VALUE syntax)