### PR TITLE
Run CI tests on user-mode-linux backend on Debian

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant:
-          - fakemachine-arch
-          - fakemachine-bookworm
-          - fakemachine-bullseye
+        # Currently nested virtualisation (hence kvm) is not supported on GitHub
+        # actions; but the qemu backend is enough to test Fakemachine
+        # functionality without hardware acceleration since the majority of code
+        # is shared between the qemu and kvm backends.
+        # See https://github.com/actions/runner-images/issues/183
+        # 
+        # For Arch Linux uml is not yet supported, so only test under qemu there.
+        os: [bullseye, bookworm]
+        backend: [qemu, uml]
+        include:
+          - os: arch
+            backend: qemu
+    name: Test ${{matrix.os}} with ${{matrix.backend}} backend
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/${{matrix.variant}}:main
+      image: ghcr.io/go-debos/test-containers/fakemachine-${{matrix.os}}:main
+      options: >-
+        --security-opt label=disable
+        --cap-add=SYS_PTRACE
+        --tmpfs /scratch:exec
+    env:
+      TMP: /scratch
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -37,8 +52,8 @@ jobs:
     - name: Test build
       run: go build -o fakemachine cmd/fakemachine/main.go
 
-    - name: Run unit tests
-      run: go test -v ./... | tee test.out
+    - name: Run unit tests (${{matrix.backend}} backend)
+      run: go test -v ./... --backend=${{matrix.backend}} | tee test.out
 
     - name: Ensure no tests were skipped
       run: "! grep -q SKIP test.out"

--- a/machine_test.go
+++ b/machine_test.go
@@ -10,13 +10,15 @@ import (
 	"testing"
 )
 
+var backendName string
+
+func init() {
+	flag.StringVar(&backendName, "backend", "auto", "Fakemachine backend to use")
+}
+
 func CreateMachine(t *testing.T) *Machine {
-	/* Automatically choose a backend and skip the test if no backends are
-	   supported in this environment. */
-	machine, err := NewMachineWithBackend("auto")
-	if err != nil {
-		t.Skip(err)
-	}
+	machine, err := NewMachineWithBackend(backendName)
+	assert.Nil(t, err)
 	machine.SetNumCPUs(2)
 
 	return machine

--- a/machine_test.go
+++ b/machine_test.go
@@ -51,7 +51,7 @@ func TestImage(t *testing.T) {
 
 	_, err := m.CreateImage("test.img", 1024*1024)
 	assert.Nil(t, err)
-	exitcode, _ := m.Run("test -b /dev/vda")
+	exitcode, _ := m.Run("test -b /dev/disk/by-fakemachine-label/fakedisk-0")
 
 	if exitcode != 0 {
 		t.Fatalf("Test for the virtual image device failed with %d", exitcode)


### PR DESCRIPTION
Currently we only run the tests on the qemu backend, which
misses all of the user-mode-linux backend functionality;
specifically fakemachine setup/teardown steps. We need to be
able to reliably test all backends in CI to be able to merge
any related changes with any confidence.

For now, only testing on the Debian base containers is
supported. More container baselines may be added as follow-up
pull requests.

Requires https://github.com/go-debos/test-containers/pull/11