### PR TITLE
backend_qemu: Avoid file ID collisions when multiple mounts share the same host path

### DIFF
--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -216,7 +216,7 @@ func (b qemuBackend) StartQemu(kvm bool) (bool, error) {
 
 	for _, point := range m.mounts {
 		qemuargs = append(qemuargs, "-virtfs",
-			fmt.Sprintf("local,mount_tag=%s,path=%s,security_model=none",
+			fmt.Sprintf("local,mount_tag=%s,path=%s,security_model=none,multidevs=remap",
 				point.label, point.hostDirectory))
 	}
 


### PR DESCRIPTION
Currently we get a useful warning like:

9p: Multiple devices detected in same VirtFS export, which might lead to file ID collisions and severe misbehaviours on guest!
You should either use a separate export for each device shared from host or use virtfs option 'multidevs=remap'!

So let's add the option to avoid the issue. Requires QEMU >= 4.2.0

[Emil Velikov]
 - Rebase, tweak commit message
