### PR TITLE
Add diskswap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Application Options:
   -c, --cpus=                       Number of CPUs for the fakemachine
   -s, --scratchsize=                On-disk scratch space size (with a unit suffix, e.g. 4G); if unset,
                                     memory backed scratch space is used
+      --swapsize=                   On-disk swap space size (with a unit suffix, e.g. 2G); if unset,
+                                    swap size will be zero
       --show-boot                   Show boot/console messages from the fakemachine
 
 Help Options:

--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -17,6 +17,7 @@ type Options struct {
 	Memory      int               `short:"m" long:"memory" description:"Amount of memory for the fakemachine in megabytes"`
 	CPUs        int               `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine"`
 	ScratchSize string            `short:"s" long:"scratchsize" description:"On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used"`
+	SwapSize    string            `long:"swapsize" description:"On-disk swap space size (with a unit suffix, e.g. 2G); if unset, swap size will be zero"`
 	ShowBoot    bool              `long:"show-boot" description:"Show boot/console messages from the fakemachine"`
 }
 
@@ -164,6 +165,15 @@ func main() {
 			os.Exit(1)
 		}
 		m.SetScratch(size, "")
+	}
+
+	if options.SwapSize != "" {
+		size, err := units.FromHumanSize(options.SwapSize)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fakemachine: Couldn't parse swap size: %v\n", err)
+			os.Exit(1)
+		}
+		m.SetSwap(size, "")
 	}
 
 	if options.Memory > 0 {

--- a/machine_test.go
+++ b/machine_test.go
@@ -136,6 +136,28 @@ fi
 	}
 }
 
+func TestSwap(t *testing.T) {
+	t.Parallel()
+	m := CreateMachine(t)
+
+	// We set the size in bytes, while the proc file uses KB
+	m.SetSwap(1024*1024, "")
+	// Nasty hack, this gets a chunk of shell script inserted in the wrapper script
+	// which is not really what fakemachine expects but seems good enough for
+	// testing
+	command := `
+SWAP=$(grep -v Filename /proc/swaps | awk ' { print $3 } ' )
+if [ ${SWAP} -lt 900 -o ${SWAP} -gt 1024 ] ; then
+  exit 1
+fi
+`
+	exitcode, _ := m.Run(command)
+
+	if exitcode != 0 {
+		t.Fatalf("Test for swap file failed with %d", exitcode)
+	}
+}
+
 func TestSpawnMachine(t *testing.T) {
 	t.Parallel()
 	if InMachine() {


### PR DESCRIPTION
This PR adds support for disk backed swap. While that in itself is self-explanatory there are couple of notable points - what brought us here and some implementation details:

 - We've been using debos with dracut, which in itself uses `/var/tmp` instead of `/tmp` for its temporary folder. That in itself is not an issue, until you consider that `/var` may be size constrained for various reasons
 
 - As we can see in the `SetSwap()` comment - the `path` argument is unused, although the API is written to align with `SetScratch()`. We can keep thing as-is, drop `path` in the new API or in both. In the last case, we're breaking the public API so might want to bump the major.
 
There's no preference on my end we the implementation details point.