### PR TITLE
bors: Delete merged branches on main repository

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,2 @@
 status = [ "bors" ]
+delete_merged_branches = true


### PR DESCRIPTION
Once bors merges a branch from the main (i.e. this) repository, the original wip branch isn't removed. Add the configuration to delete the branch after the merge has completed.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>