### PR TITLE
Bringup user-mode-linux backend on Arch Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/fakemachine-${{matrix.os}}:main
+      image: ghcr.io/go-debos/test-containers/fakemachine-${{matrix.os}}:wip-obbardc-arch-uml
       options: >-
         --security-opt label=disable
         --cap-add=SYS_PTRACE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,8 @@ jobs:
         # functionality without hardware acceleration since the majority of code
         # is shared between the qemu and kvm backends.
         # See https://github.com/actions/runner-images/issues/183
-        # 
-        # For Arch Linux uml is not yet supported, so only test under qemu there.
-        os: [bullseye, bookworm]
+        os: [bullseye, bookworm, arch]
         backend: [qemu, uml]
-        include:
-          - os: arch
-            backend: qemu
     name: Test ${{matrix.os}} with ${{matrix.backend}} backend
     runs-on: ubuntu-latest
     defaults:

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -50,11 +50,14 @@ func (b umlBackend) KernelRelease() (string, error) {
 
 func (b umlBackend) KernelPath() (string, error) {
 	// find the UML binary
-	kernelPath, err := exec.LookPath("linux.uml")
-	if err != nil {
-		return "", fmt.Errorf("user-mode-linux not installed")
+	kernelBinaries := []string{"linux.uml", "vmlinux"}
+	for _, p := range kernelBinaries {
+		if path, err := exec.LookPath(p); err == nil {
+			return path, nil
+		}
 	}
-	return kernelPath, nil
+
+	return "", fmt.Errorf("user-mode-linux not installed")
 }
 
 func (b umlBackend) ModulePath() (string, error) {


### PR DESCRIPTION
With https://github.com/go-debos/test-containers/pull/12 we
added support for User Mode Linux in the Arch Linux containers.
Enable the tests during CI runs.

(draft until https://github.com/go-debos/test-containers/pull/12 is merged)