### PR TITLE
Ensure systemd-resolved binary is available at runtime

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -662,6 +662,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		return -1, err
 	}
 
+	/* Ensure systemd-resolved is available */
+	if _, err := os.Stat("/lib/systemd/systemd-resolved"); err != nil {
+		return -1, err
+	}
+
 	/* Amd64 dynamic linker */
 	err = w.CopyFile("/lib64/ld-linux-x86-64.so.2")
 	if err != nil {


### PR DESCRIPTION
Debian Unstable (and Fedora) has split systemd-resovled into a separate package which enables systemd-resolved as the default name resolver at install-time. Because of this, we cannot simply depend on systemd-resolved in the distro packaging as this may cause the default name resolver to change to systemd-resolved for some users.
    
If the user does not have system-resolved installed, fakemachine will currently fails with any action which requires hostname resolution:

    2022/09/19 10:49:09 ==== debootstrap ====
    2022/09/19 10:49:09 Debootstrap | W: Unable to read /etc/apt/apt.conf.d/ - DirectoryExists (2: No such file or directory)
    2022/09/19 10:49:09 Debootstrap | W: Unable to read /etc/apt/apt.conf.d/ - DirectoryExists (2: No such file or directory)
    2022/09/19 10:49:09 Debootstrap | I: Target architecture can be executed
    2022/09/19 10:49:09 Debootstrap | I: Retrieving InRelease
    2022/09/19 10:49:09 Debootstrap | I: Retrieving Release
    2022/09/19 10:49:09 Debootstrap | E: Failed getting release file http://deb.debian.org/debian/dists/stable/Release
    2022/09/19 10:49:09 debootstrap.log | amd64: ok
    2022/09/19 10:49:09 debootstrap.log | wget: unable to resolve host address 'deb.debian.org'
    2022/09/19 10:49:09 debootstrap.log | wget: unable to resolve host address 'deb.debian.org'

Instead of forcing the user to install systemd-resolved, detect whether the user has the binary installed and bubble up an error earlier if the binary has not been found.
    
See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1020288
See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1020690

--
Requires https://github.com/go-debos/test-containers/pull/14 to be merged first.