### PR TITLE
gitignore: Correctly match fakemachine binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-fakemachine
+/fakemachine
 .*swp


### PR DESCRIPTION
Currently we match any file or folder called fakemachine, which means that any changes to files in b/cmd/fakemachine/ have to be forced via "git add --force"

Signed-off-by: Emil Velikov <emil.velikov@collabora.com>