### PR TITLE
Do not automatically select the qemu backend

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -43,6 +43,12 @@ func newBackend(name string, m *Machine) (backend, error) {
 	if name == "auto" {
 		for _, backend := range backends {
 			backendName := backend.Name()
+
+			/* The qemu backend is slow, don't allow users to auto-select it */
+			if backendName == "qemu" {
+				continue
+			}
+
 			b, backendErr := newBackend(backendName, m)
 			if backendErr != nil {
 				err = fmt.Errorf("%v, %v", err, backendErr)


### PR DESCRIPTION
The qemu backend is only useful for CI testing where KVM isn't available. Do not allow users to automatically choose this backend as it is far too slow for regular use.

Let the CI and power-users opt-in to using this backend by manually selecting it (either from the API or by passing --backend=qemu).