### PR TITLE
Add arm64 support & fixes for running on /usr-merged/Fedora systems

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,5 +1,5 @@
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux
+// +build linux
 
 package fakemachine
 

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -1,5 +1,5 @@
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux
+// +build linux
 
 package fakemachine
 
@@ -27,6 +27,11 @@ func (b umlBackend) Name() string {
 }
 
 func (b umlBackend) Supported() (bool, error) {
+	// only support amd64
+	if b.machine.arch != Amd64 {
+		return false, fmt.Errorf("unsupported arch: %s", b.machine.arch)
+	}
+
 	// check the kernel exists
 	if _, err := b.KernelPath(); err != nil {
 		return false, err

--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -197,7 +197,7 @@ func (w *WriterHelper) CopyFileTo(src, dst string) error {
 
 	f, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("open failed: %s - %v", src, err)
+		return fmt.Errorf("open failed: %s - %w", src, err)
 	}
 	defer f.Close()
 

--- a/machine.go
+++ b/machine.go
@@ -681,7 +681,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	}
 
 	/* Ensure systemd-resolved is available */
-	if _, err := os.Stat("/lib/systemd/systemd-resolved"); err != nil {
+	if _, err := os.Stat(prefix + "/lib/systemd/systemd-resolved"); err != nil {
 		return -1, err
 	}
 
@@ -689,9 +689,9 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	if m.arch == Arm64 {
 		// arm64 dynamic linker is in /lib:
 		// https://sourceware.org/bugzilla/show_bug.cgi?id=25129
-		dynamicLinker = "/lib/ld-linux-aarch64.so.1"
+		dynamicLinker = prefix + "/lib/ld-linux-aarch64.so.1"
 	} else {
-		dynamicLinker = "/lib64/ld-linux-x86-64.so.2"
+		dynamicLinker = prefix + "/lib64/ld-linux-x86-64.so.2"
 	}
 
 	/* dynamic linker */

--- a/machine.go
+++ b/machine.go
@@ -217,8 +217,16 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	if _, err := os.Stat("/etc/ca-certificates"); err == nil {
 		m.AddVolume("/etc/ca-certificates")
 	}
+	if _, err := os.Stat("/etc/pki"); err == nil {
+		m.AddVolume("/etc/pki")
+	}
 	if _, err := os.Stat("/etc/ssl"); err == nil {
 		m.AddVolume("/etc/ssl")
+	}
+
+	// Mounts for gnutls (used by wget).
+	if _, err := os.Stat("/etc/crypto-policies"); err == nil {
+		m.AddVolume("/etc/crypto-policies")
 	}
 
 	// Dbus configuration


### PR DESCRIPTION
For the arm64 support, this uses a very different approach from #30, but still generalizes things enough to add support for other architectures in the future. Tested to build an Apertis image from a Fedora host.