### PR TITLE
Wrap errors where possible and makes sense

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -71,7 +71,7 @@ func newBackend(name string, m *Machine) (backend, error) {
 
 	// check backend is supported
 	if supported, err := b.Supported(); !supported {
-		return nil, fmt.Errorf("%s backend not supported: %v", name, err)
+		return nil, fmt.Errorf("%s backend not supported: %w", name, err)
 	}
 
 	return b, nil

--- a/machine.go
+++ b/machine.go
@@ -833,7 +833,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	success, err := backend.Start()
 	if !success || err != nil {
-		return -1, fmt.Errorf("error starting %s backend: %v", backend.Name(), err)
+		return -1, fmt.Errorf("error starting %s backend: %w", backend.Name(), err)
 	}
 
 	result, err := os.Open(path.Join(tmpdir, "result"))
@@ -867,7 +867,7 @@ func (m *Machine) RunInMachineWithArgs(args []string) (int, error) {
 	executable, err := exec.LookPath(os.Args[0])
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to find executable: %v\n", err)
+		return -1, fmt.Errorf("Failed to find executable: %w\n", err)
 	}
 
 	return m.startup(command, [][2]string{{executable, name}})


### PR DESCRIPTION
Using `%w` instead of `%v` makes `Errorf` store the original error, allowing the caller to extract and use it later. While there isn’t any immediate benefit from it now, it may be useful to the users of fakemachine.

See:
 * https://go.dev/doc/go1.13#error_wrapping
 * https://github.com/golang/go/wiki/ErrorValueFAQ
 * https://go.googlesource.com/proposal/+/master/design/29934-error-values.md