### PR TITLE
Recurse indirect module dependencies

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -68,6 +68,16 @@ func getModDepends(modname string, kernelRelease string) []string {
 		}
 	}
 
+	// Busybox expects a full dependency list for each module rather than just
+	// direct dependencies, so recurse the module dependency tree:
+	// https://github.com/mirror/busybox/blob/1dd2685dcc735496d7adde87ac60b9434ed4a04c/modutils/modprobe.c#L46-L49
+	var sublist []string
+	for _, mod := range modlist {
+		sublist = append(sublist, getModDepends(mod, kernelRelease)...)
+	}
+
+	modlist = append(modlist, sublist...)
+
 	return modlist
 }
 


### PR DESCRIPTION
Fixes #148 

The module copying code already maintains a map of copied modules, so things aren't copied twice, so this shouldn't have too much of a performance impact.

This allows me to successfully boot the Ubuntu kernel mentioned in the issue report.