### PR TITLE
Add support for arm64 hosts

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,5 +1,5 @@
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux
+// +build linux
 
 package fakemachine
 

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -1,5 +1,5 @@
-//go:build linux && amd64
-// +build linux,amd64
+//go:build linux
+// +build linux
 
 package fakemachine
 
@@ -27,6 +27,11 @@ func (b umlBackend) Name() string {
 }
 
 func (b umlBackend) Supported() (bool, error) {
+	// only support amd64
+	if b.machine.arch != Amd64 {
+		return false, fmt.Errorf("unsupported arch: %s", b.machine.arch)
+	}
+
 	// check the kernel exists
 	if _, err := b.KernelPath(); err != nil {
 		return false, err


### PR DESCRIPTION
This adds infrastructure for support different types of host systems, specifically adding arm64 support.

Tested on an rpi4 with Debian bullseye

Based on a patch by Ryan Gonzalez <ryan.gonzalez@collabora.com>