### PR TITLE
backend: Rework newBackend() error handling

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -51,7 +51,12 @@ func newBackend(name string, m *Machine) (backend, error) {
 
 			b, backendErr := newBackend(backendName, m)
 			if backendErr != nil {
-				err = fmt.Errorf("%v, %v", err, backendErr)
+				/* Append the error to existing error */
+				if err != nil {
+					err = fmt.Errorf("%w, %w", err, backendErr)
+				} else {
+					err = fmt.Errorf("%w", backendErr)
+				}
 				continue
 			}
 			return b, nil


### PR DESCRIPTION
The newBackend() function may enumerate multiple backends to find the best supported backend for the system. Because of this, the function may return multiple errors.

There are two problems with how this function returns multiple errors:
 - if only one error occurs, the error is appended to a nil error
 - they are wrapped with %v instead of %w

Correct these issues.