### PR TITLE
Enable errorlint linter & fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - errorlint
     - gofmt
     - stylecheck
     - whitespace

--- a/backend.go
+++ b/backend.go
@@ -51,7 +51,15 @@ func newBackend(name string, m *Machine) (backend, error) {
 
 			b, backendErr := newBackend(backendName, m)
 			if backendErr != nil {
-				err = fmt.Errorf("%v, %v", err, backendErr)
+				/* Append the error to any existing backend creation error(s).
+				 * Since we cannot join errors together in golang <1.20, instead
+				 * join the error messages strings and return that as a new error.
+				 */
+				if err != nil {
+					err = fmt.Errorf("%v, %v", err.Error(), backendErr.Error())
+				} else {
+					err = backendErr
+				}
 				continue
 			}
 			return b, nil

--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"github.com/docker/go-units"
 	"github.com/go-debos/fakemachine"
@@ -141,8 +142,8 @@ func main() {
 
 	args, err := parser.Parse()
 	if err != nil {
-		flagsErr, ok := err.(*flags.Error)
-		if ok && flagsErr.Type == flags.ErrHelp {
+		var flagsErr *flags.Error
+		if errors.As(err, &flagsErr) && flagsErr.Type == flags.ErrHelp {
 			os.Exit(0)
 		} else {
 			os.Exit(1)


### PR DESCRIPTION
This linter primarily checks that errors are wrapped with %v. Enable it & fix the lint errors which occur.