### PR TITLE
Disable plymouth boot splash

### DIFF
--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -224,6 +224,7 @@ func (b qemuBackend) StartQemu(kvm bool) (bool, error) {
 	qemuargs = append(qemuargs, "-machine", qemuMachine.machine)
 	console := fmt.Sprintf("console=%s", qemuMachine.console)
 	kernelargs := []string{console, "panic=-1",
+		"plymouth.enable=0",
 		"systemd.unit=fakemachine.service"}
 
 	if m.showBoot {

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -205,7 +205,7 @@ func (b umlBackend) Start() (bool, error) {
 		"mem=" + memory + "M",
 		"initrd=" + m.initrdpath,
 		"panic=-1",
-		"nosplash",
+		"plymouth.enable=0",
 		"systemd.unit=fakemachine.service",
 		"console=tty0",
 	}


### PR DESCRIPTION
If plymouth is installed in the host, the service  will be started during
the fakemachine's boot sequence. When plymouth starts, it attempts to
clear all of the the serial consoles which in turn causes the host's
shell to be cleared.

If fakemachine is ran with --show-boot this causes the boot log to be
lost and can also cause strange artifacts on the shell (e.g. missing
characters).

Add plymouth.enable=0 to the kernel arguments to stop plymouth from
starting during the machine's boot. The uml backend has the quiet parameter
which was added to achieve the same goal, so unify the kernel arguments
between the backends.