### PR TITLE
qemu: Explicitly depend on e1000 module

### DIFF
--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -184,7 +184,7 @@ func (b qemuBackend) MountParameters(mount mountPoint) (string, []string) {
 }
 
 func (b qemuBackend) InitModules() []string {
-	return []string{"virtio_pci", "virtio_console", "9pnet_virtio", "9p"}
+	return []string{"virtio_pci", "virtio_console", "9pnet_virtio", "9p", "e1000"}
 }
 
 func (b qemuBackend) InitStaticVolumes() []mountPoint {


### PR DESCRIPTION
We use the e1000 module for the virtualised ethernet adaptor inside the qemu guest. For Debian, e1000 is builtin to the kernel so we haven't needed to include it as a dependency. When running fakemachine on Ubuntu Jammy, fakemachine fails to setup the network as e1000 is built as a module. Include e1000 in the list of required modules such that we support either case: e1000 builtin or built as a module.