### PR TITLE
qemu: Use virtio network card rather then e1000

### DIFF
--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -211,6 +211,7 @@ func (b qemuBackend) StartQemu(kvm bool) (bool, error) {
 		"-kernel", kernelPath,
 		"-initrd", m.initrdpath,
 		"-display", "none",
+		"-nic", "user,model=virtio-net-pci",
 		"-no-reboot"}
 
 	if kvm {


### PR DESCRIPTION
Instead of using the (default) qemu emulated e1000 card use a virtio-net card instead which should give a small performance boost.