### PR TITLE
qemu: explicitly set kernel log level

### DIFF
--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -235,6 +235,7 @@ func (b qemuBackend) StartQemu(kvm bool) (bool, error) {
 		qemuargs = append(qemuargs,
 			"-chardev", "stdio,id=for-ttyS0,signal=off",
 			"-serial", "chardev:for-ttyS0")
+		kernelargs = append(kernelargs, "loglevel=7")
 	} else {
 		qemuargs = append(qemuargs,
 			// Create the bus for virtio consoles


### PR DESCRIPTION
Debian kernels tend to be build with a default console loglevel of 7, but other distributions such as arch may not. To get consistent behaviour for show-boot mode