### PR TITLE
Shellescape command line arguments

### DIFF
--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/alessio/shellescape"
 	"github.com/docker/go-units"
 	"github.com/go-debos/fakemachine"
 	"github.com/jessevdk/go-flags"
@@ -181,7 +182,7 @@ func main() {
 
 	command := "/bin/bash"
 	if len(args) > 0 {
-		command = strings.Join(args, " ")
+		command = shellescape.QuoteCommand(args)
 	}
 
 	ret, err := m.Run(command)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-debos/fakemachine
 go 1.15
 
 require (
+	github.com/alessio/shellescape v1.4.2
 	github.com/docker/go-units v0.5.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/klauspost/compress v1.15.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
+github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/machine.go
+++ b/machine.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/alessio/shellescape"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -894,8 +895,8 @@ func (m *Machine) Run(command string) (int, error) {
 func (m *Machine) RunInMachineWithArgs(args []string) (int, error) {
 	name := path.Join("/", path.Base(os.Args[0]))
 
-	// FIXME: shell escaping?
-	command := strings.Join(append([]string{name}, args...), " ")
+	quotedArgs := shellescape.QuoteCommand(args)
+	command := strings.Join([]string{name, quotedArgs}, " ")
 
 	executable, err := exec.LookPath(os.Args[0])
 
@@ -909,10 +910,5 @@ func (m *Machine) RunInMachineWithArgs(args []string) (int, error) {
 // RunInMachine runs the caller binary inside the fakemachine with the same
 // commandline arguments as the parent
 func (m *Machine) RunInMachine() (int, error) {
-	name := path.Join("/", path.Base(os.Args[0]))
-
-	// FIXME: shell escaping?
-	command := strings.Join(append([]string{name}, os.Args[1:]...), " ")
-
-	return m.startup(command, [][2]string{{os.Args[0], name}})
+	return m.RunInMachineWithArgs(os.Args[1:])
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -12,9 +12,11 @@ import (
 )
 
 var backendName string
+var testArg string
 
 func init() {
 	flag.StringVar(&backendName, "backend", "auto", "Fakemachine backend to use")
+	flag.StringVar(&testArg, "testarg", "", "Test specific argument")
 }
 
 func CreateMachine(t *testing.T) *Machine {
@@ -216,4 +218,23 @@ func TestVolumes(t *testing.T) {
 	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run", "TestVolumes"})
 	require.Equal(t, exitcode, -1)
 	require.Error(t, err)
+}
+
+func TestCommandEscaping(t *testing.T) {
+	t.Parallel()
+	if InMachine() {
+		t.Log("Running in the machine")
+		require.Equal(t, testArg, "$s'n\\akes")
+		t.Log(testArg)
+		return
+	}
+
+	m := CreateMachine(t)
+	exitcode, _ := m.RunInMachineWithArgs([]string{
+		"-test.v", "-test.run",
+		"TestCommandEscaping", "-testarg", "$s'n\\akes"})
+
+	if exitcode != 0 {
+		t.Fatalf("Expected 0 but got %d", exitcode)
+	}
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -90,7 +90,7 @@ func TestScratchTmp(t *testing.T) {
 
 	m := CreateMachine(t)
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run TestScratchTmp"})
+	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchTmp"})
 
 	if exitcode != 0 {
 		t.Fatalf("Test for tmpfs mount on scratch failed with %d", exitcode)
@@ -107,7 +107,7 @@ func TestScratchDisk(t *testing.T) {
 	m := CreateMachine(t)
 	m.SetScratch(1024*1024*1024, "")
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run TestScratchDisk"})
+	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchDisk"})
 
 	if exitcode != 0 {
 		t.Fatalf("Test for device mount on scratch failed with %d", exitcode)
@@ -145,7 +145,7 @@ func TestSpawnMachine(t *testing.T) {
 
 	m := CreateMachine(t)
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run TestSpawnMachine"})
+	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestSpawnMachine"})
 
 	if exitcode != 0 {
 		t.Fatalf("Test for respawning in the machine failed failed with %d", exitcode)
@@ -180,7 +180,7 @@ func TestImageLabel(t *testing.T) {
 	labeled, err := m.CreateImageWithLabel("test-labeled.img", 1024*1024, "test-labeled")
 	require.Nil(t, err)
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run TestImageLabel", autolabel, labeled})
+	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImageLabel", autolabel, labeled})
 	if exitcode != 0 {
 		t.Fatalf("Test for images in the machine failed failed with %d", exitcode)
 	}
@@ -197,7 +197,7 @@ func TestVolumes(t *testing.T) {
 	m := CreateMachine(t)
 	m.AddVolume("random_directory_never_exists")
 
-	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run TestVolumes"})
+	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestVolumes"})
 	require.Equal(t, exitcode, -1)
 	require.Error(t, err)
 
@@ -205,7 +205,7 @@ func TestVolumes(t *testing.T) {
 	m = CreateMachine(t)
 	m.AddVolume("/dev/zero")
 
-	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run TestVolumes"})
+	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run", "TestVolumes"})
 	require.Equal(t, exitcode, -1)
 	require.Error(t, err)
 
@@ -213,7 +213,7 @@ func TestVolumes(t *testing.T) {
 	m = CreateMachine(t)
 	m.AddVolumeAt("/dev", "/dev ices")
 
-	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run TestVolumes"})
+	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run", "TestVolumes"})
 	require.Equal(t, exitcode, -1)
 	require.Error(t, err)
 }


### PR DESCRIPTION
The various fakemachine Run* functions end up running the provided commands in a shell, so add escaping to the arguments  