### PR TITLE
ci: use generic test container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/fakemachine-${{matrix.os}}:main
+      image: ghcr.io/go-debos/test-containers/${{matrix.os}}:main
       options: >-
         --security-opt label=disable
         --cap-add=SYS_PTRACE


### PR DESCRIPTION
In go-debos/test-containers#30 we simplified the test containers by only creating one container for both fakemachine/debos instead of creating separate containers for each project. Use the new container.

Draft because:
- Depends on https://github.com/go-debos/test-containers/pull/30
- Container tag needs to change to `main`