### PR TITLE
Fix systemd-networkd-wait-online race

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -105,9 +105,6 @@ type backend interface {
 	// A list of udev rules
 	UdevRules() []string
 
-	// The match expression used for the networkd configuration
-	NetworkdMatch() string
-
 	// The tty used for the job output
 	JobOutputTTY() string
 

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -162,10 +162,6 @@ func (b qemuBackend) UdevRules() []string {
 	return udevRules
 }
 
-func (b qemuBackend) NetworkdMatch() string {
-	return "e*"
-}
-
 func (b qemuBackend) JobOutputTTY() string {
 	// By default we send job output to the second virtio console,
 	// reserving /dev/ttyS0 for boot messages (which we ignore)

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -100,10 +100,6 @@ func (b umlBackend) UdevRules() []string {
 	return udevRules
 }
 
-func (b umlBackend) NetworkdMatch() string {
-	return "vec*"
-}
-
 func (b umlBackend) JobOutputTTY() string {
 	// Send the fakemachine job output to the right console
 	if b.machine.showBoot {

--- a/machine.go
+++ b/machine.go
@@ -286,7 +286,7 @@ exec /lib/systemd/systemd
 `
 const networkdTemplate = `
 [Match]
-Name=%[1]s
+Type=ether
 
 [Network]
 DHCP=ipv4
@@ -808,7 +808,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	}
 
 	err = w.WriteFile("/etc/systemd/network/ethernet.network",
-		fmt.Sprintf(networkdTemplate, backend.NetworkdMatch()), 0444)
+		networkdTemplate, 0444)
 	if err != nil {
 		return -1, err
 	}

--- a/machine.go
+++ b/machine.go
@@ -294,8 +294,18 @@ DHCP=ipv4
 LinkLocalAddressing=no
 IPv6AcceptRA=no
 `
+
+const networkdLinkTemplate = `
+[Match]
+Type=ether
+
+[Link]
+# Give the interface a static name
+Name=ethernet0
+`
+
 const commandWrapper = `#!/bin/sh
-/lib/systemd/systemd-networkd-wait-online -q
+/lib/systemd/systemd-networkd-wait-online -q --interface=ethernet0
 if [ $? != 0 ]; then
   echo "WARNING: Network setup failed"
   echo "== Journal =="
@@ -799,6 +809,12 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	err = w.WriteFile("/etc/systemd/network/ethernet.network",
 		fmt.Sprintf(networkdTemplate, backend.NetworkdMatch()), 0444)
+	if err != nil {
+		return -1, err
+	}
+
+	err = w.WriteFile("/etc/systemd/network/10-ethernet.link",
+		networkdLinkTemplate, 0444)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Older versions of systemd-networkd-wait-online (e.g. <253) will happily just exit without error if no links are available. This causes a race condition where in some cases a fakemachine will be created with no network interface.

Fix this by giving the network interface a proper name when it is created and waiting for that specific network interface to go online.