### PR TITLE
Also run tests on self-hosted kvm runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,14 @@ jobs:
         #
         # For Arch Linux uml is not yet supported, so only test under qemu there.
         os: [bullseye, bookworm, trixie]
-        backend: [qemu, uml]
+        backend: [qemu, uml, kvm]
         include:
           - os: arch
-            backend: qemu
+            backend: "qemu"
+          - os: arch
+            backend: "kvm"
     name: Test ${{matrix.os}} with ${{matrix.backend}} backend
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.backend == 'kvm' && 'kvm' || 'ubuntu-latest' }}
     defaults:
       run:
         shell: bash
@@ -64,6 +66,7 @@ jobs:
         --security-opt label=disable
         --cap-add=SYS_PTRACE
         --tmpfs /scratch:exec
+        ${{ matrix.backend == 'kvm' && '--device /dev/kvm' || '' }}
     env:
       TMP: /scratch
     steps:


### PR DESCRIPTION
kvm is the recommended backend for fakemachine; Unfortunately github hosted runners don't support virtualization. Luckily the debos organisation now has a kvm supported self-hosted runner sponsored by Collabora