### PR TITLE
Drop support for Debian bullseye/golang 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         # See https://github.com/actions/runner-images/issues/183
         #
         # For Arch Linux uml is not yet supported, so only test under qemu there.
-        os: [bullseye, bookworm, trixie]
+        os: [bookworm, trixie]
         backend: [qemu, uml, kvm]
         include:
           - os: arch


### PR DESCRIPTION
Dependencies are slowly moving to newer minimal golang version making it impossible to update them while still supporting Debian bullseye. Drop requiring support for that version now that bookworm has been out for quite a while