### PR TITLE
Expose java configuration directories in the fakemachine

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -238,6 +238,15 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 		m.AddVolume("/etc/ssl")
 	}
 
+	// Mounts for java VM configuration, especialy security policies
+	matches, _ := filepath.Glob("/etc/java*")
+	for _, path := range matches {
+		stat, err := os.Stat(path)
+		if err == nil && stat.IsDir() {
+			m.AddVolume(path)
+		}
+	}
+
 	// Dbus configuration
 	if _, err := os.Stat("/etc/dbus-1"); err == nil {
 		m.AddVolume("/etc/dbus-1")


### PR DESCRIPTION
openjdk, at least on debian, places its default profiles and security configuration in /etc/java-<version>-openjdk. For some functionality of java those files are required so add them into the fakemachine.

Note this adds all /etc/java* directories for robustness so we don't regress if the path pattern somewhat changes.