### PR TITLE
Use github runners for kvm tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - os: arch
             backend: "kvm"
     name: Test ${{matrix.os}} with ${{matrix.backend}} backend
-    runs-on: ${{ matrix.backend == 'kvm' && 'kvm' || 'ubuntu-latest' }}
+    runs-on: 'ubuntu-latest'
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
With the github upgraded to newer/bigger runners virtualisation seems to work so run those tests on the github runners again