### PR TITLE
Fix compatibility when kmod module_directory prefixed with /usr

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -99,11 +99,6 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 		return nil
 	}
 
-	prefix := ""
-	if mergedUsrSystem() {
-		prefix = "/usr"
-	}
-
 	found := false
 	for suffix, fn := range suffixes {
 		if strings.HasSuffix(modpath, suffix) {
@@ -115,8 +110,15 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 
 			// The suffix is the complete thing - ".ko.foobar"
 			// Reinstate the required ".ko" part, after trimming.
-			basepath := strings.TrimSuffix(modpath, suffix) + ".ko"
-			if err := w.TransformFileTo(modpath, prefix+basepath, fn); err != nil {
+			dest := strings.TrimSuffix(modpath, suffix) + ".ko"
+
+			// Ensure destination has /usr prefix if running
+			// on merged-usr system.
+			if mergedUsrSystem() && !strings.HasPrefix(dest, "/usr") {
+				dest = "/usr" + dest
+			}
+
+			if err := w.TransformFileTo(modpath, dest, fn); err != nil {
 				return err
 			}
 			found = true


### PR DESCRIPTION
Debian's kmod now builds with `--with-module-directory=/usr/lib/modules`[1]
(while the default is `--with-module-directory=/lib/modules`) which means
that `modinfo` now outputs module paths with `/usr` prefix already.

In fakemachine, on merged-usr systems, modules are copied into the initrd
with a prefixed path of `/usr`, no matter the system path produced by modinfo.
This means that modules are now copied into the wrong place, e.g /usr/usr/....

Fix compatibility with kmod built with /usr prefixed module-directory by
ensuring the module destination path has a prefix of /usr, rather than
always prefixing the destination path with /usr.

[1]: https://salsa.debian.org/md/kmod/-/commit/3306fbb10a8ff6c3bd643437e8f29353872524fd
Fixes: https://github.com/go-debos/fakemachine/issues/194