### PR TITLE
enable network on ipv6-only hosts

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -337,8 +337,8 @@ Description=fakemachine runner
 Conflicts=shutdown.target
 Before=shutdown.target
 Requires=basic.target
-Wants=systemd-resolved.service binfmt-support.service systemd-networkd.service
-After=basic.target systemd-resolved.service binfmt-support.service systemd-networkd.service
+Wants=systemd-resolved.service binfmt-support.service network-online.target
+After=basic.target systemd-resolved.service binfmt-support.service network-online.target
 OnFailure=poweroff.target
 
 [Service]

--- a/machine.go
+++ b/machine.go
@@ -301,9 +301,6 @@ Type=ether
 
 [Network]
 DHCP=ipv4
-# Disable link-local address to speedup boot
-LinkLocalAddressing=no
-IPv6AcceptRA=no
 `
 
 const networkdLinkTemplate = `


### PR DESCRIPTION
The networkd template explicitly disables IPv6-connectivity. When connecting to a host, the attempt to use IPv6 results in -ENETUNREACH from the guest kernel. If the host is IPv6-only, the host kernel likewise makes attempts to use IPv4 result in -ENETUNREACH. Hence fakemachine has dysfunctional network when invoked on an IPv6-only host.

Closes: #207