### PR TITLE
Replace depreciated functions from ioutils package

### DIFF
--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -5,7 +5,6 @@ package fakemachine
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -85,7 +84,7 @@ func (b qemuBackend) KernelRelease() (string, error) {
 		return release, nil
 	}
 
-	files, err := ioutil.ReadDir("/lib/modules")
+	files, err := os.ReadDir("/lib/modules")
 	if err != nil {
 		return "", err
 	}

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -6,7 +6,6 @@ package fakemachine
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -71,7 +70,7 @@ func (b umlBackend) ModulePath() (string, error) {
 	}
 
 	// find the subdirectory containing the modules for the UML release
-	modSubdirs, err := ioutil.ReadDir(moddir)
+	modSubdirs, err := os.ReadDir(moddir)
 	if err != nil {
 		return "", err
 	}

--- a/machine.go
+++ b/machine.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/alessio/shellescape"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -609,7 +609,7 @@ func (m *Machine) setupscratch() error {
 		return nil
 	}
 
-	tmpfile, err := ioutil.TempFile(m.scratchpath, "fake-scratch.img.")
+	tmpfile, err := os.CreateTemp(m.scratchpath, "fake-scratch.img.")
 	if err != nil {
 		return err
 	}
@@ -659,7 +659,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		}
 	}
 
-	tmpdir, err := ioutil.TempDir("", "fakemachine-")
+	tmpdir, err := os.MkdirTemp("", "fakemachine-")
 	if err != nil {
 		return -1, err
 	}
@@ -902,7 +902,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		return -1, err
 	}
 
-	exitstr, _ := ioutil.ReadAll(result)
+	exitstr, _ := io.ReadAll(result)
 	exitcode, err := strconv.Atoi(strings.TrimSpace(string(exitstr)))
 
 	if err != nil {


### PR DESCRIPTION
ioutils has been depreciated since Go 1.19; since Go 1.16 [bookworm] the same functionality is provided by the io or os packages. Use the new packages instead.