### PR TITLE
Deprecate user-mode-linux backend

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -44,6 +44,11 @@ func newBackend(name string, m *Machine) (backend, error) {
 		for _, backend := range backends {
 			backendName := backend.Name()
 
+			/* The user-mode-linux backend is flaky, don't allow users to auto-select it */
+			if backendName == "uml" {
+				continue
+			}
+
 			/* The qemu backend is slow, don't allow users to auto-select it */
 			if backendName == "qemu" {
 				continue

--- a/backend.go
+++ b/backend.go
@@ -11,8 +11,8 @@ import (
 func implementedBackends(m *Machine) []backend {
 	return []backend{
 		newKvmBackend(m),
-		newUmlBackend(m),
 		newQemuBackend(m),
+		newUmlBackend(m),
 	}
 }
 

--- a/backend.go
+++ b/backend.go
@@ -49,11 +49,6 @@ func newBackend(name string, m *Machine) (backend, error) {
 				continue
 			}
 
-			/* The qemu backend is slow, don't allow users to auto-select it */
-			if backendName == "qemu" {
-				continue
-			}
-
 			b, backendErr := newBackend(backendName, m)
 			if backendErr != nil {
 				/* Append the error to any existing backend creation error(s).

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -140,6 +140,10 @@ func (b umlBackend) InitStaticVolumes() []mountPoint {
 func (b umlBackend) Start() (bool, error) {
 	m := b.machine
 
+	if !m.quiet {
+		fmt.Printf("WARNING: uml backend is flaky and unsupported\n")
+	}
+
 	kernelPath, err := b.KernelPath()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Remove user-mode-linux backend from automatic backend selection & allow user-mode-linux backend to be used manually along with a warning. Remove the user-mode-linux CI tests.