### PR TITLE
golangci: Use same golangci checks as debos

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,22 +8,9 @@ linters:
     - staticcheck
     - whitespace
   exclusions:
-    generated: lax
     presets:
       - comments
-      - common-false-positives
-      - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gofmt
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$


### PR DESCRIPTION
Unify golang linters between debos/fakemachine.

Closes: #254 