### PR TITLE
Keep GitHub workflow alive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,18 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
+  # Keep workflow alive
+  # See https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    needs:
+      - allgreen
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1.2.1
+
   # Notify on job failure
   notify-on-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub disables workflows if there is no activity in the repository after 60 days. Run a separate standalone job to re-enable the workflow on a regular scheduled job.

See https://github.com/go-debos/test-containers/pull/35