### PR TITLE
golangci: Enable wrapcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - revive
     - staticcheck
     - whitespace
+    - wrapcheck
   exclusions:
     presets:
       - comments

--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -179,8 +179,10 @@ func (w *WriterHelper) WriteCharDevice(device string, major, minor int64, perm o
 }
 
 func (w *WriterHelper) CopyTree(path string) error {
-	walker := func(p string, info os.FileInfo, _ error) error {
-		var err error
+	walker := func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("error visiting %s: %w", p, err)
+		}
 		if info.Mode().IsDir() {
 			err = w.WriteDirectory(p, info.Mode() & ^os.ModeType)
 		} else if info.Mode().IsRegular() {

--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -258,7 +258,7 @@ func (w *WriterHelper) TransformFileTo(src, dst string, fn Transformer) error {
 	out := new(bytes.Buffer)
 	err = fn(out, f)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to transform source file %s: %w", src, err)
 	}
 
 	hdr := new(cpio.Header)

--- a/decompressors.go
+++ b/decompressors.go
@@ -2,6 +2,7 @@ package fakemachine
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io"
 
 	"github.com/klauspost/compress/zstd"
@@ -11,38 +12,50 @@ import (
 func ZstdDecompressor(dst io.Writer, src io.Reader) error {
 	decompressor, err := zstd.NewReader(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create zstd decompressor: %w", err)
 	}
 	defer decompressor.Close()
 
 	_, err = io.Copy(dst, decompressor)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to decompress zstd data: %w", err)
+	}
+	return nil
 }
 
 func XzDecompressor(dst io.Writer, src io.Reader) error {
 	decompressor, err := xz.NewReader(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create xz decompressor: %w", err)
 	}
 	// There is no Close() API. See: https://github.com/ulikunitz/xz/issues/45
 	//defer decompressor.Close()
 
 	_, err = io.Copy(dst, decompressor)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to decompress xz data: %w", err)
+	}
+	return nil
 }
 
 func GzipDecompressor(dst io.Writer, src io.Reader) error {
 	decompressor, err := gzip.NewReader(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create gzip decompressor: %w", err)
 	}
 	defer decompressor.Close()
 
 	_, err = io.Copy(dst, decompressor)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to decompress gzip data: %w", err)
+	}
+	return nil
 }
 
 func NullDecompressor(dst io.Writer, src io.Reader) error {
 	_, err := io.Copy(dst, src)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to copy uncompressed data: %w", err)
+	}
+	return nil
 }

--- a/decompressors_test.go
+++ b/decompressors_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -24,12 +25,12 @@ func checkStreamsMatch(t *testing.T, output, check io.Reader) error {
 				return nil
 			}
 			if oerr != nil && oerr != io.EOF {
-				t.Errorf("Error reading output stream: %s", oerr)
-				return oerr
+				t.Errorf("Error reading output stream: %v", oerr)
+				return fmt.Errorf("error reading output stream: %w", oerr)
 			}
 			if cerr != nil && cerr != io.EOF {
-				t.Errorf("Error reading check stream: %s", cerr)
-				return cerr
+				t.Errorf("Error reading check stream: %v", cerr)
+				return fmt.Errorf("error reading check stream: %w", cerr)
 			}
 			return nil
 		}

--- a/machine.go
+++ b/machine.go
@@ -660,6 +660,230 @@ func (m *Machine) cleanup() {
 	m.scratchfile = ""
 }
 
+func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr error) {
+	f, err := os.OpenFile(m.initrdpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create initrd file: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close initrd file: %w", cerr)
+		}
+	}()
+
+	kernelModuleDir, err := m.backend.ModulePath()
+	if err != nil {
+		return fmt.Errorf("failed to get kernel module directory: %w", err)
+	}
+
+	w := writerhelper.NewWriterHelper(f)
+	defer func() {
+		if cerr := w.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close cpio writer: %w", cerr)
+		}
+	}()
+
+	err = w.WriteDirectories([]writerhelper.WriteDirectory{
+		{Directory: "/scratch", Perm: 01777},
+		{Directory: "/var/tmp", Perm: 01777},
+		{Directory: "/var/lib/dbus", Perm: 0755},
+		{Directory: "/tmp", Perm: 01777},
+		{Directory: "/sys", Perm: 0755},
+		{Directory: "/proc", Perm: 0755},
+		{Directory: "/run", Perm: 0755},
+		{Directory: "/usr", Perm: 0755},
+		{Directory: "/usr/bin", Perm: 0755},
+		{Directory: "/lib64", Perm: 0755},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write directories: %w", err)
+	}
+
+	err = w.WriteSymlink("/run", "/var/run", 0755)
+	if err != nil {
+		return fmt.Errorf("failed to write /var/run symlink: %w", err)
+	}
+
+	if mergedUsrSystem() {
+		err = w.WriteSymlinks([]writerhelper.WriteSymlink{
+			{Target: "/usr/sbin", Link: "/sbin", Perm: 0755},
+			{Target: "/usr/bin", Link: "/bin", Perm: 0755},
+			{Target: "/usr/lib", Link: "/lib", Perm: 0755},
+			{Target: "/usr/lib64", Link: "/lib64", Perm: 0755},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to write merged-usr symlinks: %w", err)
+		}
+	} else {
+		err = w.WriteDirectories([]writerhelper.WriteDirectory{
+			{Directory: "/sbin", Perm: 0744},
+			{Directory: "/bin", Perm: 0755},
+			{Directory: "/lib", Perm: 0755},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to write non-merged-usr directories: %w", err)
+		}
+	}
+
+	prefix := ""
+	if mergedUsrSystem() {
+		prefix = "/usr"
+	}
+
+	// search for busybox; in some distros it's located under /sbin
+	busybox, err := exec.LookPath("busybox")
+	if err != nil {
+		return fmt.Errorf("failed to find busybox: %w", err)
+	}
+	err = w.CopyFileTo(busybox, prefix+"/bin/busybox")
+	if err != nil {
+		return fmt.Errorf("failed to copy busybox: %w", err)
+	}
+
+	/* Ensure systemd-resolved is available */
+	if _, err := os.Stat("/lib/systemd/systemd-resolved"); err != nil {
+		return fmt.Errorf("systemd-resolved not found: %w", err)
+	}
+
+	dynamicLinker := archDynamicLinker[m.arch]
+	err = w.CopyFile(prefix + dynamicLinker)
+	if err != nil {
+		return fmt.Errorf("failed to copy dynamic linker: %w", err)
+	}
+
+	/* C libraries */
+	libraryDir, err := realDir(dynamicLinker)
+	if err != nil {
+		return err
+	}
+	err = w.CopyFile(libraryDir + "/libc.so.6")
+	if err != nil {
+		return fmt.Errorf("failed to copy libc.so.6: %w", err)
+	}
+	err = w.CopyFile(libraryDir + "/libresolv.so.2")
+	if err != nil {
+		return fmt.Errorf("failed to copy libresolv.so.2: %w", err)
+	}
+
+	err = w.WriteCharDevice("/dev/console", 5, 1, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to write /dev/console device: %w", err)
+	}
+
+	// Linker configuration
+	err = w.CopyFile("/etc/ld.so.conf")
+	if err != nil {
+		return fmt.Errorf("failed to copy ld.so.conf: %w", err)
+	}
+
+	err = w.CopyTree("/etc/ld.so.conf.d")
+	if err != nil {
+		return fmt.Errorf("failed to copy ld.so.conf.d: %w", err)
+	}
+
+	// Core system configuration
+	err = w.WriteFile("/etc/machine-id", "", 0444)
+	if err != nil {
+		return fmt.Errorf("failed to write machine-id: %w", err)
+	}
+
+	err = w.WriteFile("/etc/hostname", "fakemachine", 0444)
+	if err != nil {
+		return fmt.Errorf("failed to write hostname: %w", err)
+	}
+
+	err = w.CopyFile("/etc/passwd")
+	if err != nil {
+		return fmt.Errorf("failed to copy passwd: %w", err)
+	}
+
+	err = w.CopyFile("/etc/group")
+	if err != nil {
+		return fmt.Errorf("failed to copy group: %w", err)
+	}
+
+	err = w.CopyFile("/etc/nsswitch.conf")
+	if err != nil {
+		return fmt.Errorf("failed to copy nsswitch.conf: %w", err)
+	}
+
+	// udev rules
+	udevRules := strings.Join(m.backend.UdevRules(), "\n") + "\n"
+	err = w.WriteFile("/etc/udev/rules.d/61-fakemachine.rules", udevRules, 0444)
+	if err != nil {
+		return fmt.Errorf("failed to write udev rules: %w", err)
+	}
+
+	err = w.WriteFile("/etc/systemd/network/ethernet.network",
+		networkdTemplate, 0444)
+	if err != nil {
+		return fmt.Errorf("failed to write ethernet.network: %w", err)
+	}
+
+	err = w.WriteFile("/etc/systemd/network/10-ethernet.link",
+		networkdLinkTemplate, 0444)
+	if err != nil {
+		return fmt.Errorf("failed to write ethernet.link: %w", err)
+	}
+
+	err = w.WriteSymlink(
+		"/lib/systemd/resolv.conf",
+		"/etc/resolv.conf",
+		0755)
+	if err != nil {
+		return fmt.Errorf("failed to write resolv.conf symlink: %w", err)
+	}
+
+	err = m.writerKernelModules(w, kernelModuleDir, m.backend.InitModules())
+	if err != nil {
+		return fmt.Errorf("failed to write kernel modules: %w", err)
+	}
+
+	err = w.WriteFile("etc/systemd/system/fakemachine.service",
+		fmt.Sprintf(serviceTemplate, m.backend.JobOutputTTY(), strings.Join(m.Environ, " ")), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write fakemachine.service: %w", err)
+	}
+
+	err = w.WriteSymlink(
+		"/lib/systemd/system/serial-getty@ttyS0.service",
+		"/dev/null",
+		0755)
+	if err != nil {
+		return fmt.Errorf("failed to write serial-getty symlink: %w", err)
+	}
+
+	err = w.WriteFile("/wrapper",
+		fmt.Sprintf(commandWrapper, command), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to write wrapper script: %w", err)
+	}
+
+	init, err := executeInitScriptTemplate(m, m.backend)
+	if err != nil {
+		return err
+	}
+
+	err = w.WriteFileRaw("/init", init, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to write init script: %w", err)
+	}
+
+	err = m.generateFstab(w, m.backend)
+	if err != nil {
+		return fmt.Errorf("failed to generate fstab: %w", err)
+	}
+
+	for _, v := range extracontent {
+		err = w.CopyFileTo(v[0], v[1])
+		if err != nil {
+			return fmt.Errorf("failed to copy extra content %s: %w", v[0], err)
+		}
+	}
+
+	return nil
+}
+
 // Start the machine running the given command and adding the extra content to
 // the cpio. Extracontent is a list of {source, dest} tuples
 func (m *Machine) startup(command string, extracontent [][2]string) (int, error) {
@@ -699,229 +923,17 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	}
 
 	m.initrdpath = path.Join(tmpdir, "initramfs.cpio")
-	f, err := os.OpenFile(m.initrdpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-
-	if err != nil {
-		return -1, fmt.Errorf("failed to create initrd file: %w", err)
-	}
-
-	backend := m.backend
-
-	kernelModuleDir, err := backend.ModulePath()
-	if err != nil {
-		return -1, fmt.Errorf("failed to get kernel module directory: %w", err)
-	}
-
-	w := writerhelper.NewWriterHelper(f)
-
-	err = w.WriteDirectories([]writerhelper.WriteDirectory{
-		{Directory: "/scratch", Perm: 01777},
-		{Directory: "/var/tmp", Perm: 01777},
-		{Directory: "/var/lib/dbus", Perm: 0755},
-		{Directory: "/tmp", Perm: 01777},
-		{Directory: "/sys", Perm: 0755},
-		{Directory: "/proc", Perm: 0755},
-		{Directory: "/run", Perm: 0755},
-		{Directory: "/usr", Perm: 0755},
-		{Directory: "/usr/bin", Perm: 0755},
-		{Directory: "/lib64", Perm: 0755},
-	})
-	if err != nil {
-		return -1, fmt.Errorf("failed to write directories: %w", err)
-	}
-
-	err = w.WriteSymlink("/run", "/var/run", 0755)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write /var/run symlink: %w", err)
-	}
-
-	if mergedUsrSystem() {
-		err = w.WriteSymlinks([]writerhelper.WriteSymlink{
-			{Target: "/usr/sbin", Link: "/sbin", Perm: 0755},
-			{Target: "/usr/bin", Link: "/bin", Perm: 0755},
-			{Target: "/usr/lib", Link: "/lib", Perm: 0755},
-			{Target: "/usr/lib64", Link: "/lib64", Perm: 0755},
-		})
-		if err != nil {
-			return -1, fmt.Errorf("failed to write merged-usr symlinks: %w", err)
-		}
-	} else {
-		err = w.WriteDirectories([]writerhelper.WriteDirectory{
-			{Directory: "/sbin", Perm: 0744},
-			{Directory: "/bin", Perm: 0755},
-			{Directory: "/lib", Perm: 0755},
-		})
-		if err != nil {
-			return -1, fmt.Errorf("failed to write non-merged-usr directories: %w", err)
-		}
-	}
-
-	prefix := ""
-	if mergedUsrSystem() {
-		prefix = "/usr"
-	}
-
-	// search for busybox; in some distros it's located under /sbin
-	busybox, err := exec.LookPath("busybox")
-	if err != nil {
-		return -1, fmt.Errorf("failed to find busybox: %w", err)
-	}
-	err = w.CopyFileTo(busybox, prefix+"/bin/busybox")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy busybox: %w", err)
-	}
-
-	/* Ensure systemd-resolved is available */
-	if _, err := os.Stat("/lib/systemd/systemd-resolved"); err != nil {
-		return -1, fmt.Errorf("systemd-resolved not found: %w", err)
-	}
-
-	dynamicLinker := archDynamicLinker[m.arch]
-	err = w.CopyFile(prefix + dynamicLinker)
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy dynamic linker: %w", err)
-	}
-
-	/* C libraries */
-	libraryDir, err := realDir(dynamicLinker)
-	if err != nil {
+	if err := m.buildInitrd(command, extracontent); err != nil {
 		return -1, err
 	}
-	err = w.CopyFile(libraryDir + "/libc.so.6")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy libc.so.6: %w", err)
-	}
-	err = w.CopyFile(libraryDir + "/libresolv.so.2")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy libresolv.so.2: %w", err)
-	}
-
-	err = w.WriteCharDevice("/dev/console", 5, 1, 0700)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write /dev/console device: %w", err)
-	}
-
-	// Linker configuration
-	err = w.CopyFile("/etc/ld.so.conf")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy ld.so.conf: %w", err)
-	}
-
-	err = w.CopyTree("/etc/ld.so.conf.d")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy ld.so.conf.d: %w", err)
-	}
-
-	// Core system configuration
-	err = w.WriteFile("/etc/machine-id", "", 0444)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write machine-id: %w", err)
-	}
-
-	err = w.WriteFile("/etc/hostname", "fakemachine", 0444)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write hostname: %w", err)
-	}
-
-	err = w.CopyFile("/etc/passwd")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy passwd: %w", err)
-	}
-
-	err = w.CopyFile("/etc/group")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy group: %w", err)
-	}
-
-	err = w.CopyFile("/etc/nsswitch.conf")
-	if err != nil {
-		return -1, fmt.Errorf("failed to copy nsswitch.conf: %w", err)
-	}
-
-	// udev rules
-	udevRules := strings.Join(backend.UdevRules(), "\n") + "\n"
-	err = w.WriteFile("/etc/udev/rules.d/61-fakemachine.rules", udevRules, 0444)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write udev rules: %w", err)
-	}
-
-	err = w.WriteFile("/etc/systemd/network/ethernet.network",
-		networkdTemplate, 0444)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write ethernet.network: %w", err)
-	}
-
-	err = w.WriteFile("/etc/systemd/network/10-ethernet.link",
-		networkdLinkTemplate, 0444)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write ethernet.link: %w", err)
-	}
-
-	err = w.WriteSymlink(
-		"/lib/systemd/resolv.conf",
-		"/etc/resolv.conf",
-		0755)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write resolv.conf symlink: %w", err)
-	}
-
-	err = m.writerKernelModules(w, kernelModuleDir, backend.InitModules())
-	if err != nil {
-		return -1, fmt.Errorf("failed to write kernel modules: %w", err)
-	}
-
-	err = w.WriteFile("etc/systemd/system/fakemachine.service",
-		fmt.Sprintf(serviceTemplate, backend.JobOutputTTY(), strings.Join(m.Environ, " ")), 0644)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write fakemachine.service: %w", err)
-	}
-
-	err = w.WriteSymlink(
-		"/lib/systemd/system/serial-getty@ttyS0.service",
-		"/dev/null",
-		0755)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write serial-getty symlink: %w", err)
-	}
-
-	err = w.WriteFile("/wrapper",
-		fmt.Sprintf(commandWrapper, command), 0755)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write wrapper script: %w", err)
-	}
-
-	init, err := executeInitScriptTemplate(m, backend)
-	if err != nil {
-		return -1, err
-	}
-
-	err = w.WriteFileRaw("/init", init, 0755)
-	if err != nil {
-		return -1, fmt.Errorf("failed to write init script: %w", err)
-	}
-
-	err = m.generateFstab(w, backend)
-	if err != nil {
-		return -1, fmt.Errorf("failed to generate fstab: %w", err)
-	}
-
-	for _, v := range extracontent {
-		err = w.CopyFileTo(v[0], v[1])
-		if err != nil {
-			return -1, fmt.Errorf("failed to copy extra content %s: %w", v[0], err)
-		}
-	}
-
-	w.Close()
-	f.Close()
 
 	if !m.quiet {
-		fmt.Printf("Running %s using %s backend\n", command, backend.Name())
+		fmt.Printf("Running %s using %s backend\n", command, m.backend.Name())
 	}
 
-	success, err := backend.Start()
+	success, err := m.backend.Start()
 	if !success || err != nil {
-		return -1, fmt.Errorf("error starting %s backend: %w", backend.Name(), err)
+		return -1, fmt.Errorf("error starting %s backend: %w", m.backend.Name(), err)
 	}
 
 	result, err := os.Open(path.Join(tmpdir, "result"))

--- a/machine.go
+++ b/machine.go
@@ -931,12 +931,19 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		fmt.Printf("Running %s using %s backend\n", command, m.backend.Name())
 	}
 
+	// Set a default result of failure so that if the backend fails to start
+	// we get a defined exit code instead of an error reading the result file.
+	resultPath := path.Join(tmpdir, "result")
+	if err := os.WriteFile(resultPath, []byte("1"), 0644); err != nil {
+		return -1, fmt.Errorf("failed to create result file: %w", err)
+	}
+
 	success, err := m.backend.Start()
 	if !success || err != nil {
 		return -1, fmt.Errorf("error starting %s backend: %w", m.backend.Name(), err)
 	}
 
-	result, err := os.Open(path.Join(tmpdir, "result"))
+	result, err := os.Open(resultPath)
 	if err != nil {
 		return -1, fmt.Errorf("failed to open result file: %w", err)
 	}

--- a/machine.go
+++ b/machine.go
@@ -942,7 +942,10 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	}
 	defer result.Close()
 
-	exitstr, _ := io.ReadAll(result)
+	exitstr, err := io.ReadAll(result)
+	if err != nil {
+		return -1, fmt.Errorf("failed to read result file: %w", err)
+	}
 	exitcode, err := strconv.Atoi(strings.TrimSpace(string(exitstr)))
 
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -637,12 +637,13 @@ func (m *Machine) setupscratch() error {
 		return fmt.Errorf("failed to create temp file for scratch: %w", err)
 	}
 	m.scratchfile = tmpfile.Name()
+	tmpfile.Close()
 
-	m.scratchdev, err = m.CreateImageWithLabel(tmpfile.Name(), m.scratchsize, "fake-scratch")
+	m.scratchdev, err = m.CreateImageWithLabel(m.scratchfile, m.scratchsize, "fake-scratch")
 	if err != nil {
 		return err
 	}
-	mkfs := exec.Command("mkfs.ext4", "-q", tmpfile.Name())
+	mkfs := exec.Command("mkfs.ext4", "-q", m.scratchfile)
 	err = mkfs.Run()
 	if err != nil {
 		return fmt.Errorf("failed to format scratch disk: %w", err)

--- a/machine.go
+++ b/machine.go
@@ -102,10 +102,8 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 	found := false
 	for suffix, fn := range suffixes {
 		if strings.HasSuffix(modpath, suffix) {
-			// File must exist as-is on the filesystem. Aka do not
-			// fallback to other suffixes.
 			if _, err := os.Stat(modpath); err != nil {
-				return err
+				return fmt.Errorf("failed to stat module file %s: %w", modpath, err)
 			}
 
 			// The suffix is the complete thing - ".ko.foobar"
@@ -119,7 +117,7 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 			}
 
 			if err := w.TransformFileTo(modpath, dest, fn); err != nil {
-				return err
+				return fmt.Errorf("failed to transform module file %s: %w", modpath, err)
 			}
 			found = true
 			break
@@ -147,10 +145,10 @@ func realDir(path string) (string, error) {
 	var p string
 	var err error
 	if p, err = filepath.Abs(path); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get absolute path for %s: %w", path, err)
 	}
 	if p, err = filepath.EvalSymlinks(p); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to evaluate symlinks for %s: %w", p, err)
 	}
 	return filepath.Dir(p), nil
 }
@@ -403,7 +401,7 @@ func executeInitScriptTemplate(m *Machine, b backend) ([]byte, error) {
 	tmpl := template.Must(template.New("init").Funcs(helperFuncs).Parse(initScript))
 	out := &bytes.Buffer{}
 	if err := tmpl.Execute(out, tmplVariables); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to execute init script template: %w", err)
 	}
 	return out.Bytes(), nil
 }
@@ -445,7 +443,7 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (s
 	if size < 0 {
 		_, err := os.Stat(path)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to stat image file %s: %w", path, err)
 		}
 	}
 
@@ -461,13 +459,14 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (s
 
 	i, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create image file %s: %w", path, err)
 	}
 
 	if size >= 0 {
 		err = i.Truncate(size)
 		if err != nil {
-			return "", err
+			i.Close()
+			return "", fmt.Errorf("failed to truncate image file: %w", err)
 		}
 	}
 
@@ -556,7 +555,10 @@ func (m Machine) generateFstab(w *writerhelper.WriterHelper, backend backend) er
 	fstab = append(fstab, "")
 
 	err := w.WriteFile("/etc/fstab", strings.Join(fstab, "\n"), 0755)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to write fstab: %w", err)
+	}
+	return nil
 }
 
 func stripCompressionSuffix(module string) (string, error) {
@@ -587,7 +589,11 @@ func (m *Machine) generateModulesDep(w *writerhelper.WriterHelper, moddir string
 	}
 
 	path := path.Join(moddir, "modules.dep")
-	return w.WriteFile(path, strings.Join(output, "\n"), 0644)
+	err := w.WriteFile(path, strings.Join(output, "\n"), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write modules.dep: %w", err)
+	}
+	return nil
 }
 
 func (m *Machine) SetEnviron(environ []string) {
@@ -606,7 +612,7 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper, moddir strin
 
 	for _, v := range modfiles {
 		if err := w.CopyFile(moddir + "/" + v); err != nil {
-			return err
+			return fmt.Errorf("failed to copy kernel module file %s: %w", moddir+"/"+v, err)
 		}
 	}
 
@@ -628,7 +634,7 @@ func (m *Machine) setupscratch() error {
 
 	tmpfile, err := os.CreateTemp(m.scratchpath, "fake-scratch.img.")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create temp file for scratch: %w", err)
 	}
 	m.scratchfile = tmpfile.Name()
 
@@ -638,8 +644,11 @@ func (m *Machine) setupscratch() error {
 	}
 	mkfs := exec.Command("mkfs.ext4", "-q", tmpfile.Name())
 	err = mkfs.Run()
+	if err != nil {
+		return fmt.Errorf("failed to format scratch disk: %w", err)
+	}
 
-	return err
+	return nil
 }
 
 func (m *Machine) cleanup() {
@@ -678,7 +687,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	tmpdir, err := os.MkdirTemp("", "fakemachine-")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	m.AddVolumeAt(tmpdir, "/run/fakemachine")
 	defer os.RemoveAll(tmpdir)
@@ -692,14 +701,14 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	f, err := os.OpenFile(m.initrdpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to create initrd file: %w", err)
 	}
 
 	backend := m.backend
 
 	kernelModuleDir, err := backend.ModulePath()
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to get kernel module directory: %w", err)
 	}
 
 	w := writerhelper.NewWriterHelper(f)
@@ -717,12 +726,12 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		{Directory: "/lib64", Perm: 0755},
 	})
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write directories: %w", err)
 	}
 
 	err = w.WriteSymlink("/run", "/var/run", 0755)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write /var/run symlink: %w", err)
 	}
 
 	if mergedUsrSystem() {
@@ -733,7 +742,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 			{Target: "/usr/lib64", Link: "/lib64", Perm: 0755},
 		})
 		if err != nil {
-			return -1, err
+			return -1, fmt.Errorf("failed to write merged-usr symlinks: %w", err)
 		}
 	} else {
 		err = w.WriteDirectories([]writerhelper.WriteDirectory{
@@ -742,7 +751,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 			{Directory: "/lib", Perm: 0755},
 		})
 		if err != nil {
-			return -1, err
+			return -1, fmt.Errorf("failed to write non-merged-usr directories: %w", err)
 		}
 	}
 
@@ -754,22 +763,22 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	// search for busybox; in some distros it's located under /sbin
 	busybox, err := exec.LookPath("busybox")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to find busybox: %w", err)
 	}
 	err = w.CopyFileTo(busybox, prefix+"/bin/busybox")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy busybox: %w", err)
 	}
 
 	/* Ensure systemd-resolved is available */
 	if _, err := os.Stat("/lib/systemd/systemd-resolved"); err != nil {
-		return -1, err
+		return -1, fmt.Errorf("systemd-resolved not found: %w", err)
 	}
 
 	dynamicLinker := archDynamicLinker[m.arch]
 	err = w.CopyFile(prefix + dynamicLinker)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy dynamic linker: %w", err)
 	}
 
 	/* C libraries */
@@ -779,72 +788,72 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	}
 	err = w.CopyFile(libraryDir + "/libc.so.6")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy libc.so.6: %w", err)
 	}
 	err = w.CopyFile(libraryDir + "/libresolv.so.2")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy libresolv.so.2: %w", err)
 	}
 
 	err = w.WriteCharDevice("/dev/console", 5, 1, 0700)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write /dev/console device: %w", err)
 	}
 
 	// Linker configuration
 	err = w.CopyFile("/etc/ld.so.conf")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy ld.so.conf: %w", err)
 	}
 
 	err = w.CopyTree("/etc/ld.so.conf.d")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy ld.so.conf.d: %w", err)
 	}
 
 	// Core system configuration
 	err = w.WriteFile("/etc/machine-id", "", 0444)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write machine-id: %w", err)
 	}
 
 	err = w.WriteFile("/etc/hostname", "fakemachine", 0444)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write hostname: %w", err)
 	}
 
 	err = w.CopyFile("/etc/passwd")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy passwd: %w", err)
 	}
 
 	err = w.CopyFile("/etc/group")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy group: %w", err)
 	}
 
 	err = w.CopyFile("/etc/nsswitch.conf")
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to copy nsswitch.conf: %w", err)
 	}
 
 	// udev rules
 	udevRules := strings.Join(backend.UdevRules(), "\n") + "\n"
 	err = w.WriteFile("/etc/udev/rules.d/61-fakemachine.rules", udevRules, 0444)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write udev rules: %w", err)
 	}
 
 	err = w.WriteFile("/etc/systemd/network/ethernet.network",
 		networkdTemplate, 0444)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write ethernet.network: %w", err)
 	}
 
 	err = w.WriteFile("/etc/systemd/network/10-ethernet.link",
 		networkdLinkTemplate, 0444)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write ethernet.link: %w", err)
 	}
 
 	err = w.WriteSymlink(
@@ -852,18 +861,18 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		"/etc/resolv.conf",
 		0755)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write resolv.conf symlink: %w", err)
 	}
 
 	err = m.writerKernelModules(w, kernelModuleDir, backend.InitModules())
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write kernel modules: %w", err)
 	}
 
 	err = w.WriteFile("etc/systemd/system/fakemachine.service",
 		fmt.Sprintf(serviceTemplate, backend.JobOutputTTY(), strings.Join(m.Environ, " ")), 0644)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write fakemachine.service: %w", err)
 	}
 
 	err = w.WriteSymlink(
@@ -871,13 +880,13 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 		"/dev/null",
 		0755)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write serial-getty symlink: %w", err)
 	}
 
 	err = w.WriteFile("/wrapper",
 		fmt.Sprintf(commandWrapper, command), 0755)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write wrapper script: %w", err)
 	}
 
 	init, err := executeInitScriptTemplate(m, backend)
@@ -887,18 +896,18 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	err = w.WriteFileRaw("/init", init, 0755)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to write init script: %w", err)
 	}
 
 	err = m.generateFstab(w, backend)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to generate fstab: %w", err)
 	}
 
 	for _, v := range extracontent {
 		err = w.CopyFileTo(v[0], v[1])
 		if err != nil {
-			return -1, err
+			return -1, fmt.Errorf("failed to copy extra content %s: %w", v[0], err)
 		}
 	}
 
@@ -916,14 +925,14 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 
 	result, err := os.Open(path.Join(tmpdir, "result"))
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to open result file: %w", err)
 	}
 
 	exitstr, _ := io.ReadAll(result)
 	exitcode, err := strconv.Atoi(strings.TrimSpace(string(exitstr)))
 
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("failed to parse exit code: %w", err)
 	}
 
 	return exitcode, nil

--- a/machine.go
+++ b/machine.go
@@ -940,6 +940,7 @@ func (m *Machine) startup(command string, extracontent [][2]string) (int, error)
 	if err != nil {
 		return -1, fmt.Errorf("failed to open result file: %w", err)
 	}
+	defer result.Close()
 
 	exitstr, _ := io.ReadAll(result)
 	exitcode, err := strconv.Atoi(strings.TrimSpace(string(exitstr)))


### PR DESCRIPTION
Enable the wrapcheck linter to ensure error context is always passed upwards.