### PR TITLE
ci: add write packages permission to build-container job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
   build-container:
     name: Build Docker container
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - golangci
       - test


### PR DESCRIPTION
The build-container job currently cannot push containers to GHCR:

    denied: installation not allowed to Write organization package

Add `permissions: packages: write` to allow pushing containers to GHCR.