### PR TITLE
ci: Add Ubuntu and Fedora tests && update container image paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
         backend:
           - qemu
           - kvm
+        exclude:
+          - os: fedora-latest
+            backend: qemu
     name: Test ${{matrix.os}} with ${{matrix.backend}} backend
     runs-on: 'ubuntu-latest'
     defaults:


### PR DESCRIPTION
We now build test-containers for Ubuntu & Fedora. Run the fakemachine test suite on these OSs as well.

Depends on https://github.com/go-debos/test-containers/pull/57