### PR TITLE
fix broken udev symlinks for >26 disks and >9 partitions

### DIFF
--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -156,7 +156,7 @@ func (b qemuBackend) UdevRules() []string {
 		suffix := diskSuffix(i)
 		udevRules = append(udevRules,
 			fmt.Sprintf(`KERNEL=="vd%s", SYMLINK+="disk/by-fakemachine-label/%s"`, suffix, img.label),
-			fmt.Sprintf(`KERNEL=="vd%s[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, suffix, img.label))
+			fmt.Sprintf(`KERNEL=="vd%s[0-9]*", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, suffix, img.label))
 	}
 	return udevRules
 }

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -153,10 +153,10 @@ func (b qemuBackend) UdevRules() []string {
 
 	// create symlink under /dev/disk/by-fakemachine-label/ for each virtual image
 	for i, img := range b.machine.images {
-		driveLetter := 'a' + i
+		suffix := diskSuffix(i)
 		udevRules = append(udevRules,
-			fmt.Sprintf(`KERNEL=="vd%c", SYMLINK+="disk/by-fakemachine-label/%s"`, driveLetter, img.label),
-			fmt.Sprintf(`KERNEL=="vd%c[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, driveLetter, img.label))
+			fmt.Sprintf(`KERNEL=="vd%s", SYMLINK+="disk/by-fakemachine-label/%s"`, suffix, img.label),
+			fmt.Sprintf(`KERNEL=="vd%s[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, suffix, img.label))
 	}
 	return udevRules
 }

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -99,7 +99,7 @@ func (b umlBackend) UdevRules() []string {
 		suffix := diskSuffix(i)
 		udevRules = append(udevRules,
 			fmt.Sprintf(`KERNEL=="ubd%s", SYMLINK+="disk/by-fakemachine-label/%s"`, suffix, img.label),
-			fmt.Sprintf(`KERNEL=="ubd%s[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, suffix, img.label))
+			fmt.Sprintf(`KERNEL=="ubd%s[0-9]*", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, suffix, img.label))
 	}
 	return udevRules
 }

--- a/backend_uml.go
+++ b/backend_uml.go
@@ -96,10 +96,10 @@ func (b umlBackend) UdevRules() []string {
 
 	// create symlink under /dev/disk/by-fakemachine-label/ for each virtual image
 	for i, img := range b.machine.images {
-		driveLetter := 'a' + i
+		suffix := diskSuffix(i)
 		udevRules = append(udevRules,
-			fmt.Sprintf(`KERNEL=="ubd%c", SYMLINK+="disk/by-fakemachine-label/%s"`, driveLetter, img.label),
-			fmt.Sprintf(`KERNEL=="ubd%c[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, driveLetter, img.label))
+			fmt.Sprintf(`KERNEL=="ubd%s", SYMLINK+="disk/by-fakemachine-label/%s"`, suffix, img.label),
+			fmt.Sprintf(`KERNEL=="ubd%s[0-9]", SYMLINK+="disk/by-fakemachine-label/%s-part%%n"`, suffix, img.label))
 	}
 	return udevRules
 }

--- a/machine.go
+++ b/machine.go
@@ -485,6 +485,16 @@ func (m *Machine) CreateImage(imagepath string, size int64) (string, error) {
 	return m.CreateImageWithLabel(imagepath, size, label)
 }
 
+// diskSuffix returns the disk name suffix for the i-th disk (0-indexed),
+// following Linux device naming: a, b, ..., z, aa, ab, ..., az, ba, ...
+func diskSuffix(i int) string {
+	suffix := ""
+	for ; i >= 0; i = (i/26 - 1) {
+		suffix = string(rune('a'+i%26)) + suffix
+	}
+	return suffix
+}
+
 // SetMemory sets the fakemachines amount of memory (in megabytes). Defaults to
 // 2048 MB
 func (m *Machine) SetMemory(memory int) {

--- a/machine_test.go
+++ b/machine_test.go
@@ -296,6 +296,16 @@ func TestDiskSuffix(t *testing.T) {
 	}
 }
 
+func TestImageLabelUniqueness(t *testing.T) {
+	m := CreateMachine(t)
+
+	_, err := m.CreateImageWithLabel("test.img", 1024*1024, "my-disk")
+	require.NoError(t, err)
+
+	_, err = m.CreateImageWithLabel("test2.img", 1024*1024, "my-disk")
+	require.Error(t, err)
+}
+
 func TestCommandEscaping(t *testing.T) {
 	t.Parallel()
 	if InMachine() {

--- a/machine_test.go
+++ b/machine_test.go
@@ -280,6 +280,22 @@ func TestVolumes(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDiskSuffix(t *testing.T) {
+	cases := []struct {
+		i    int
+		want string
+	}{
+		{0, "a"}, {1, "b"}, {25, "z"},
+		{26, "aa"}, {27, "ab"}, {51, "az"},
+		{52, "ba"}, {701, "zz"}, {702, "aaa"},
+	}
+	for _, c := range cases {
+		if got := diskSuffix(c.i); got != c.want {
+			t.Errorf("diskSuffix(%d) = %q, want %q", c.i, got, c.want)
+		}
+	}
+}
+
 func TestCommandEscaping(t *testing.T) {
 	t.Parallel()
 	if InMachine() {


### PR DESCRIPTION
Two very minor bugs in udev rule generation caused /dev/disk/by-fakemachine-label/ symlinks to silently not be created when:

- attaching more than 26 disks
- attaching a disk with more than 9 partitions

In practice these bugs will probably never be hit by normal users of fakemachine, but let's fix these silly bugs anyway.
