### PR TITLE
machine: add SetScratchMkfsArgs to allow customising scratch mkfs options

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -197,11 +197,12 @@ type Machine struct {
 	quiet      bool
 	Environ    []string
 
-	scratchsize int64
-	scratchpath string
-	scratchfile string
-	scratchdev  string
-	initrdpath  string
+	scratchsize     int64
+	scratchpath     string
+	scratchfile     string
+	scratchdev      string
+	scratchMkfsArgs []string
+	initrdpath      string
 }
 
 // Create a new machine object with the auto backend
@@ -537,6 +538,12 @@ func (m *Machine) SetScratch(scratchsize int64, path string) {
 	}
 }
 
+// SetScratchMkfsArgs sets extra arguments passed to mkfs.ext4 when creating
+// the scratch filesystem.
+func (m *Machine) SetScratchMkfsArgs(args []string) {
+	m.scratchMkfsArgs = args
+}
+
 func (m Machine) generateFstab(w *writerhelper.WriterHelper, backend backend) error {
 	fstab := []string{"# Generated fstab file by fakemachine"}
 
@@ -636,7 +643,10 @@ func (m *Machine) setupscratch() error {
 	if err != nil {
 		return err
 	}
-	mkfs := exec.Command("mkfs.ext4", "-q", tmpfile.Name())
+
+	mkfsArgs := append([]string{"-q"}, m.scratchMkfsArgs...)
+	mkfsArgs = append(mkfsArgs, tmpfile.Name())
+	mkfs := exec.Command("mkfs.ext4", mkfsArgs...)
 	err = mkfs.Run()
 
 	return err


### PR DESCRIPTION
When the scratch filesystem is backed by a disk image it is formatted with mkfs.ext4 using only default options. Some callers may need to adjust those options. For example, debos builds for 32-bit target architectures need to disable the dir_index feature.

This is needed by https://github.com/go-debos/debos/pull/704