### PR TITLE
Propagate ignored errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   enable:
     - govet
+    - errcheck
     - errorlint
     - misspell
     - revive
@@ -11,7 +12,6 @@ linters:
   exclusions:
     presets:
       - comments
-      - std-error-handling
 formatters:
   enable:
     - gofmt

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -167,7 +167,10 @@ func (b qemuBackend) ModulePath() (string, error) {
 
 	moddir = path.Join(moddir, kernelRelease)
 	if _, err := os.Stat(moddir); err != nil {
-		return "", fmt.Errorf("module directory not found at %s: %w", moddir, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("module directory not found at %s: %w", moddir, err)
+		}
+		return "", fmt.Errorf("stat %s: %w", moddir, err)
 	}
 
 	return moddir, nil

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -82,22 +82,30 @@ func (b qemuBackend) KernelRelease() (string, error) {
 	if err := unix.Uname(&u); err != nil {
 		return "", fmt.Errorf("failed to get kernel release: %w", err)
 	}
-	release := string(u.Release[:bytes.IndexByte(u.Release[:], 0)])
 
-	if _, err := os.Stat(path.Join("/lib/modules", release)); err == nil {
+	n := bytes.IndexByte(u.Release[:], 0)
+	if n < 0 {
+		n = len(u.Release)
+	}
+	release := string(u.Release[:n])
+
+	moduleDir := path.Join("/lib/modules", release)
+	if _, err := os.Stat(moduleDir); err == nil {
 		return release, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("checking module directory %s: %w", moduleDir, err)
 	}
 
 	files, err := os.ReadDir("/lib/modules")
 	if err != nil {
-		return "", fmt.Errorf("failed to read /lib/modules: %w", err)
+		return "", fmt.Errorf("listing /lib/modules: %w", err)
 	}
 
 	for i := len(files) - 1; i >= 0; i-- {
 		/* Ensure the kernel name starts with a digit, in order
 		 * to filter out 'extramodules-ARCH' on ArchLinux */
 		filename := files[i].Name()
-		if filename[0] >= '0' && filename[0] <= '9' {
+		if len(filename) > 0 && filename[0] >= '0' && filename[0] <= '9' {
 			return filename, nil
 		}
 	}

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -332,7 +332,9 @@ func (b kvmBackend) Supported() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to open /dev/kvm: %w", err)
 	}
-	kvmDevice.Close()
+	if err := kvmDevice.Close(); err != nil {
+		return false, fmt.Errorf("failed to close /dev/kvm: %w", err)
+	}
 
 	return b.qemuBackend.Supported()
 }

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -4,6 +4,7 @@ package fakemachine
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -120,9 +121,17 @@ func (b qemuBackend) KernelPath() (string, error) {
 	 * ... perhaps because systemd requires it to allow hibernation
 	 * https://github.com/systemd/systemd/commit/edda44605f06a41fb86b7ab8128dcf99161d2344
 	 */
-	if moddir, err := b.ModulePath(); err == nil {
+	moddir, err := b.ModulePath()
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("failed to get kernel module path: %w", err)
+	}
+	if err == nil {
 		kernelPath := path.Join(moddir, "vmlinuz")
-		if _, err := os.Stat(kernelPath); err == nil {
+		if _, err := os.Stat(kernelPath); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return "", fmt.Errorf("failed to stat kernel path %s: %w", kernelPath, err)
+			}
+		} else {
 			return kernelPath, nil
 		}
 	}
@@ -133,9 +142,13 @@ func (b qemuBackend) KernelPath() (string, error) {
 		return "", err
 	}
 
-	kernelPath := "/boot/vmlinuz-" + kernelRelease
+	kernelPath := path.Join("/boot", "vmlinuz-"+kernelRelease)
 	if _, err := os.Stat(kernelPath); err != nil {
-		return "", fmt.Errorf("kernel not found at %s: %w", kernelPath, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("kernel not found at %s", kernelPath)
+		}
+
+		return "", fmt.Errorf("failed to stat kernel path %s: %w", kernelPath, err)
 	}
 
 	return kernelPath, nil

--- a/backend_qemu.go
+++ b/backend_qemu.go
@@ -161,7 +161,7 @@ func (b qemuBackend) ModulePath() (string, error) {
 	}
 
 	moddir := "/lib/modules"
-	if mergedUsrSystem() {
+	if b.machine.mergedUsr {
 		moddir = "/usr/lib/modules"
 	}
 

--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -213,6 +213,8 @@ func main() {
 			fmt.Fprintf(os.Stderr, "fakemachine: Couldn't parse scratch size: %v\n", err)
 			os.Exit(1)
 		}
+
+		// Use the current working directory as the default scratch file location
 		m.SetScratch(size, "")
 	}
 

--- a/cpio/writerhelper.go
+++ b/cpio/writerhelper.go
@@ -2,6 +2,7 @@ package writerhelper
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -201,9 +202,8 @@ func (w *WriterHelper) CopyTree(path string) error {
 	return nil
 }
 
-func (w *WriterHelper) CopyFileTo(src, dst string) error {
-	err := w.ensureBaseDirectory(path.Dir(dst))
-	if err != nil {
+func (w *WriterHelper) CopyFileTo(src, dst string) (err error) {
+	if err := w.ensureBaseDirectory(path.Dir(dst)); err != nil {
 		return err
 	}
 
@@ -211,7 +211,11 @@ func (w *WriterHelper) CopyFileTo(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("open failed: %s - %w", src, err)
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close source file %s: %w", src, closeErr))
+		}
+	}()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -238,9 +242,8 @@ func (w *WriterHelper) CopyFileTo(src, dst string) error {
 	return nil
 }
 
-func (w *WriterHelper) TransformFileTo(src, dst string, fn Transformer) error {
-	err := w.ensureBaseDirectory(path.Dir(dst))
-	if err != nil {
+func (w *WriterHelper) TransformFileTo(src, dst string, fn Transformer) (err error) {
+	if err := w.ensureBaseDirectory(path.Dir(dst)); err != nil {
 		return err
 	}
 
@@ -248,7 +251,11 @@ func (w *WriterHelper) TransformFileTo(src, dst string, fn Transformer) error {
 	if err != nil {
 		return fmt.Errorf("failed to open source file %s: %w", src, err)
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close source file %s: %w", src, closeErr))
+		}
+	}()
 
 	info, err := f.Stat()
 	if err != nil {

--- a/decompressors.go
+++ b/decompressors.go
@@ -2,6 +2,7 @@ package fakemachine
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 
@@ -38,12 +39,16 @@ func XzDecompressor(dst io.Writer, src io.Reader) error {
 	return nil
 }
 
-func GzipDecompressor(dst io.Writer, src io.Reader) error {
+func GzipDecompressor(dst io.Writer, src io.Reader) (err error) {
 	decompressor, err := gzip.NewReader(src)
 	if err != nil {
 		return fmt.Errorf("failed to create gzip decompressor: %w", err)
 	}
-	defer decompressor.Close()
+	defer func() {
+		if closeErr := decompressor.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close gzip decompressor: %w", closeErr))
+		}
+	}()
 
 	_, err = io.Copy(dst, decompressor)
 	if err != nil {

--- a/decompressors_test.go
+++ b/decompressors_test.go
@@ -13,33 +13,38 @@ import (
 	"github.com/go-debos/fakemachine/cpio"
 )
 
-func checkStreamsMatch(t *testing.T, output, check io.Reader) error {
-	i := 0
+func checkStreamsMatch(output, check io.Reader) error {
+	var i int64
+
 	oreader := bufio.NewReader(output)
 	creader := bufio.NewReader(check)
+
 	for {
 		ochar, oerr := oreader.ReadByte()
+		if oerr != nil && !errors.Is(oerr, io.EOF) {
+			return fmt.Errorf("read output stream at byte %d: %w", i, oerr)
+		}
+
 		cchar, cerr := creader.ReadByte()
-		if oerr != nil || cerr != nil {
-			if oerr == io.EOF && cerr == io.EOF {
+		if cerr != nil && !errors.Is(cerr, io.EOF) {
+			return fmt.Errorf("read check stream at byte %d: %w", i, cerr)
+		}
+
+		if errors.Is(oerr, io.EOF) || errors.Is(cerr, io.EOF) {
+			switch {
+			case errors.Is(oerr, io.EOF) && errors.Is(cerr, io.EOF):
 				return nil
+			case errors.Is(oerr, io.EOF):
+				return fmt.Errorf("output stream shorter than check stream at byte %d", i)
+			default:
+				return fmt.Errorf("check stream shorter than output stream at byte %d", i)
 			}
-			if oerr != nil && oerr != io.EOF {
-				t.Errorf("Error reading output stream: %v", oerr)
-				return fmt.Errorf("error reading output stream: %w", oerr)
-			}
-			if cerr != nil && cerr != io.EOF {
-				t.Errorf("Error reading check stream: %v", cerr)
-				return fmt.Errorf("error reading check stream: %w", cerr)
-			}
-			return nil
 		}
 
 		if ochar != cchar {
-			t.Errorf("Mismatch at byte %d, values %d (output) and %d (check)",
-				i, ochar, cchar)
-			return errors.New("Data mismatch")
+			return fmt.Errorf("data mismatch at byte %d: output=0x%02x check=0x%02x", i, ochar, cchar)
 		}
+
 		i++
 	}
 }
@@ -66,8 +71,7 @@ func decompressorTest(t *testing.T, file, suffix string, d writerhelper.Transfor
 	}
 	defer checkFile.Close()
 
-	err = checkStreamsMatch(t, output, checkFile)
-	if err != nil {
+	if err = checkStreamsMatch(output, checkFile); err != nil {
 		t.Errorf("Failed to compare streams: %s", err)
 		return
 	}

--- a/decompressors_test.go
+++ b/decompressors_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/go-debos/fakemachine/cpio"
+	"github.com/stretchr/testify/require"
 )
 
 func checkStreamsMatch(output, check io.Reader) error {
@@ -49,46 +50,57 @@ func checkStreamsMatch(output, check io.Reader) error {
 	}
 }
 
-func decompressorTest(t *testing.T, file, suffix string, d writerhelper.Transformer) {
-	f, err := os.Open(path.Join("testdata", file+suffix))
+func decompressorTest(file, suffix string, d writerhelper.Transformer) (err error) {
+	testFilePath := path.Join("testdata", file+suffix)
+	f, err := os.Open(testFilePath)
 	if err != nil {
-		t.Errorf("Unable to open test data: %s", err)
-		return
+		return fmt.Errorf("open test file %s: %w", testFilePath, err)
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close test file %s: %w", testFilePath, closeErr))
+		}
+	}()
 
 	output := new(bytes.Buffer)
-	err = d(output, f)
-	if err != nil {
-		t.Errorf("Error whilst decompressing test file: %s", err)
-		return
+	if err := d(output, f); err != nil {
+		return fmt.Errorf("decompress test file %s: %w", testFilePath, err)
 	}
 
-	checkFile, err := os.Open(path.Join("testdata", file))
+	checkFilePath := path.Join("testdata", file)
+	checkFile, err := os.Open(checkFilePath)
 	if err != nil {
-		t.Errorf("Unable to open check data: %s", err)
-		return
+		return fmt.Errorf("open check file %s: %w", checkFilePath, err)
 	}
-	defer checkFile.Close()
+	defer func() {
+		if closeErr := checkFile.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close check file %s: %w", checkFilePath, closeErr))
+		}
+	}()
 
-	if err = checkStreamsMatch(output, checkFile); err != nil {
-		t.Errorf("Failed to compare streams: %s", err)
-		return
+	if err := checkStreamsMatch(output, checkFile); err != nil {
+		return fmt.Errorf("compare decompressed output: %w", err)
 	}
+
+	return nil
 }
 
 func TestZstd(t *testing.T) {
-	decompressorTest(t, "test", ".zst", ZstdDecompressor)
+	err := decompressorTest("test", ".zst", ZstdDecompressor)
+	require.NoError(t, err)
 }
 
 func TestXz(t *testing.T) {
-	decompressorTest(t, "test", ".xz", XzDecompressor)
+	err := decompressorTest("test", ".xz", XzDecompressor)
+	require.NoError(t, err)
 }
 
 func TestGzip(t *testing.T) {
-	decompressorTest(t, "test", ".gz", GzipDecompressor)
+	err := decompressorTest("test", ".gz", GzipDecompressor)
+	require.NoError(t, err)
 }
 
 func TestNull(t *testing.T) {
-	decompressorTest(t, "test", "", NullDecompressor)
+	err := decompressorTest("test", "", NullDecompressor)
+	require.NoError(t, err)
 }

--- a/machine.go
+++ b/machine.go
@@ -92,7 +92,7 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 	release, _ := m.backend.KernelRelease()
 	modpath := getModPath(modname, release)
 	if modpath == "" {
-		return fmt.Errorf("kernel module '%s' not found for kernel release '%s'", modname, release)
+		return fmt.Errorf("kernel module %q not found for kernel release %q", modname, release)
 	}
 
 	if modpath == "(builtin)" || copiedModules[modname] {
@@ -448,12 +448,12 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (s
 	}
 
 	if len(label) >= 20 {
-		return "", fmt.Errorf("label '%s' too long; cannot be more then 20 characters", label)
+		return "", fmt.Errorf("image label %q too long; cannot be more than 20 characters", label)
 	}
 
 	for _, image := range m.images {
 		if image.label == label {
-			return "", fmt.Errorf("label '%s' already exists", label)
+			return "", fmt.Errorf("image with label %q already exists", label)
 		}
 	}
 

--- a/machine.go
+++ b/machine.go
@@ -1019,7 +1019,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 		return -1, fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	m.AddVolumeAt(tmpdir, "/run/fakemachine")
-	defer os.RemoveAll(tmpdir)
+	defer func() {
+		if removeErr := os.RemoveAll(tmpdir); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to remove tempdir %s: %w", tmpdir, removeErr))
+		}
+	}()
 
 	err = m.setupscratch()
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -31,10 +31,10 @@ func mergedUsrSystem() bool {
 // Parse modinfo output and return the value of module attributes
 // There may be multiple row with same fieldname so []string
 // is used to return all data.
-func getModData(modname string, fieldname string, kernelRelease string) []string {
+func getModData(modname string, fieldname string, kernelRelease string) ([]string, error) {
 	out, err := exec.Command("modinfo", "-k", kernelRelease, modname).Output()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to call modinfo for module %q and kernel release %q: %w", modname, kernelRelease, err)
 	}
 
 	var fieldValue []string
@@ -46,21 +46,28 @@ func getModData(modname string, fieldname string, kernelRelease string) []string
 			fieldValue = append(fieldValue, strings.TrimSpace(field[1]))
 		}
 	}
-	return fieldValue
+	return fieldValue, nil
 }
 
 // Get full path of module
-func getModPath(modname string, kernelRelease string) string {
-	path := getModData(modname, "filename", kernelRelease)
-	if len(path) != 0 {
-		return path[0]
+func getModPath(modname string, kernelRelease string) (string, error) {
+	path, err := getModData(modname, "filename", kernelRelease)
+	if err != nil {
+		return "", err
 	}
-	return ""
+	if len(path) == 0 {
+		return "", fmt.Errorf("could not find path for module %q", modname)
+	}
+
+	return path[0], nil
 }
 
 // Get all dependent module
-func getModDepends(modname string, kernelRelease string) []string {
-	deplist := getModData(modname, "depends", kernelRelease)
+func getModDepends(modname string, kernelRelease string) ([]string, error) {
+	deplist, err := getModData(modname, "depends", kernelRelease)
+	if err != nil {
+		return nil, err
+	}
 	var modlist []string
 	for _, v := range deplist {
 		if v != "" {
@@ -73,12 +80,16 @@ func getModDepends(modname string, kernelRelease string) []string {
 	// https://github.com/mirror/busybox/blob/1dd2685dcc735496d7adde87ac60b9434ed4a04c/modutils/modprobe.c#L46-L49
 	var sublist []string
 	for _, mod := range modlist {
-		sublist = append(sublist, getModDepends(mod, kernelRelease)...)
+		deps, err := getModDepends(mod, kernelRelease)
+		if err != nil {
+			return nil, fmt.Errorf("get dependencies for module %q: %w", mod, err)
+		}
+		sublist = append(sublist, deps...)
 	}
 
 	modlist = append(modlist, sublist...)
 
-	return modlist
+	return modlist, nil
 }
 
 var suffixes = map[string]writerhelper.Transformer{
@@ -89,10 +100,13 @@ var suffixes = map[string]writerhelper.Transformer{
 }
 
 func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copiedModules map[string]bool) error {
-	release, _ := m.backend.KernelRelease()
-	modpath := getModPath(modname, release)
-	if modpath == "" {
-		return fmt.Errorf("kernel module %q not found for kernel release %q", modname, release)
+	release, err := m.backend.KernelRelease()
+	if err != nil {
+		return fmt.Errorf("failed to get kernel release: %w", err)
+	}
+	modpath, err := getModPath(modname, release)
+	if err != nil {
+		return fmt.Errorf("kernel module %q not found for kernel release %q: %w", modname, release, err)
 	}
 
 	if modpath == "(builtin)" || copiedModules[modname] {
@@ -103,7 +117,7 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 	for suffix, fn := range suffixes {
 		if strings.HasSuffix(modpath, suffix) {
 			if _, err := os.Stat(modpath); err != nil {
-				return fmt.Errorf("failed to stat module file %s: %w", modpath, err)
+				return fmt.Errorf("failed to stat module file %q: %w", modpath, err)
 			}
 
 			// The suffix is the complete thing - ".ko.foobar"
@@ -117,7 +131,7 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 			}
 
 			if err := w.TransformFileTo(modpath, dest, fn); err != nil {
-				return fmt.Errorf("failed to transform module file %s: %w", modpath, err)
+				return fmt.Errorf("failed to transform module file %q: %w", modpath, err)
 			}
 			found = true
 			break
@@ -129,7 +143,10 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 
 	copiedModules[modname] = true
 
-	deplist := getModDepends(modname, release)
+	deplist, err := getModDepends(modname, release)
+	if err != nil {
+		return fmt.Errorf("failed to get dependencies for kernel module %q: %w", modname, err)
+	}
 	for _, mod := range deplist {
 		if err := m.copyModules(w, mod, copiedModules); err != nil {
 			return err
@@ -574,14 +591,34 @@ func stripCompressionSuffix(module string) (string, error) {
 
 func (m *Machine) generateModulesDep(w *writerhelper.WriterHelper, moddir string, modules map[string]bool) error {
 	output := make([]string, len(modules))
-	release, _ := m.backend.KernelRelease()
+	release, err := m.backend.KernelRelease()
+	if err != nil {
+		return fmt.Errorf("failed to get kernel release: %w", err)
+	}
 	i := 0
 	for mod := range modules {
-		modpath, _ := stripCompressionSuffix(getModPath(mod, release)) // CANNOT fail
-		deplist := getModDepends(mod, release)                         // CANNOT fail
+		modpath, err := getModPath(mod, release)
+		if err != nil {
+			return fmt.Errorf("failed to get path for module %q: %w", mod, err)
+		}
+		modpath, err = stripCompressionSuffix(modpath)
+		if err != nil {
+			return fmt.Errorf("failed to strip compression suffix for module %q: %w", mod, err)
+		}
+		deplist, err := getModDepends(mod, release)
+		if err != nil {
+			return fmt.Errorf("failed to get dependencies for module %q: %w", mod, err)
+		}
 		deps := make([]string, len(deplist))
 		for j, dep := range deplist {
-			deppath, _ := stripCompressionSuffix(getModPath(dep, release)) // CANNOT fail
+			deppath, err := getModPath(dep, release)
+			if err != nil {
+				return fmt.Errorf("failed to get path for dependency %q of module %q: %w", dep, mod, err)
+			}
+			deppath, err = stripCompressionSuffix(deppath)
+			if err != nil {
+				return fmt.Errorf("failed to strip compression suffix for dependency %q of module %q: %w", dep, mod, err)
+			}
 			deps[j] = deppath
 		}
 		output[i] = fmt.Sprintf("%s: %s", modpath, strings.Join(deps, " "))
@@ -589,8 +626,7 @@ func (m *Machine) generateModulesDep(w *writerhelper.WriterHelper, moddir string
 	}
 
 	path := path.Join(moddir, "modules.dep")
-	err := w.WriteFile(path, strings.Join(output, "\n"), 0644)
-	if err != nil {
+	if err := w.WriteFile(path, strings.Join(output, "\n"), 0644); err != nil {
 		return fmt.Errorf("failed to write modules.dep: %w", err)
 	}
 	return nil

--- a/machine.go
+++ b/machine.go
@@ -981,8 +981,12 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (err err
 
 // Start the machine running the given command and adding the extra content to
 // the cpio. Extracontent is a list of {source, dest} tuples
-func (m *Machine) startup(command string, extracontent [][2]string) (int, error) {
-	defer m.cleanup()
+func (m *Machine) startup(command string, extracontent [][2]string) (code int, err error) {
+	defer func() {
+		if cleanupErr := m.cleanup(); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("cleanup failed: %w", cleanupErr))
+		}
+	}()
 
 	os.Setenv("PATH", os.Getenv("PATH")+":/sbin:/usr/sbin")
 

--- a/machine.go
+++ b/machine.go
@@ -173,6 +173,30 @@ func realDir(path string) (string, error) {
 	return filepath.Dir(p), nil
 }
 
+// addVolumeIfExists adds volumePath as a machine volume if it exists on the host.
+//
+// It returns true if the volume was added. A missing path is not treated as an
+// error and returns false, nil. If the path exists but is not a directory, or
+// cannot be checked, it returns false and an error.
+func (m *Machine) addVolumeIfExists(volumePath string) (bool, error) {
+	stat, err := os.Stat(volumePath)
+
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to check %q: %w", volumePath, err)
+	}
+
+	if !stat.IsDir() {
+		return false, fmt.Errorf("failed to add volume %q: not a directory", volumePath)
+	}
+
+	m.AddVolume(volumePath)
+	return true, nil
+}
+
 type Arch string
 
 const (
@@ -259,11 +283,11 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	}
 
 	// Mounts for ssl certificates
-	if _, err := os.Stat("/etc/ca-certificates"); err == nil {
-		m.AddVolume("/etc/ca-certificates")
+	if _, err := m.addVolumeIfExists("/etc/ca-certificates"); err != nil {
+		return nil, err
 	}
-	if _, err := os.Stat("/etc/ssl"); err == nil {
-		m.AddVolume("/etc/ssl")
+	if _, err := m.addVolumeIfExists("/etc/ssl"); err != nil {
+		return nil, err
 	}
 
 	// Mounts for java VM configuration, especially security policies
@@ -276,17 +300,18 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	}
 
 	// Dbus configuration
-	if _, err := os.Stat("/etc/dbus-1"); err == nil {
-		m.AddVolume("/etc/dbus-1")
+	if _, err := m.addVolumeIfExists("/etc/dbus-1"); err != nil {
+		return nil, err
 	}
 
 	// Debian alternative symlinks
-	if _, err := os.Stat("/etc/alternatives"); err == nil {
-		m.AddVolume("/etc/alternatives")
+	if _, err := m.addVolumeIfExists("/etc/alternatives"); err != nil {
+		return nil, err
 	}
-	// Debians binfmt registry
-	if _, err := os.Stat("/var/lib/binfmts"); err == nil {
-		m.AddVolume("/var/lib/binfmts")
+
+	// Debian binfmt registry
+	if _, err := m.addVolumeIfExists("/var/lib/binfmts"); err != nil {
+		return nil, err
 	}
 
 	return m, nil

--- a/machine.go
+++ b/machine.go
@@ -563,10 +563,10 @@ func (m Machine) generateFstab(w *writerhelper.WriterHelper, backend backend) er
 
 func stripCompressionSuffix(module string) (string, error) {
 	for suffix := range suffixes {
-		if strings.HasSuffix(module, suffix) {
-			// The suffix is the complete thing - ".ko.foobar"
-			// Reinstate the required ".ko" part, after trimming.
-			return strings.TrimSuffix(module, suffix) + ".ko", nil
+		// The suffix is the complete thing - ".ko.foobar"
+		// Reinstate the required ".ko" part, after trimming.
+		if trimmed, ok := strings.CutSuffix(module, suffix); ok {
+			return trimmed + ".ko", nil
 		}
 	}
 	return "", errors.New("module extension/suffix unknown")

--- a/machine.go
+++ b/machine.go
@@ -988,7 +988,9 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 		}
 	}()
 
-	os.Setenv("PATH", os.Getenv("PATH")+":/sbin:/usr/sbin")
+	if err := os.Setenv("PATH", os.Getenv("PATH")+":/sbin:/usr/sbin"); err != nil {
+		return -1, fmt.Errorf("failed to set PATH: %w", err)
+	}
 
 	/* Sanity check mountpoints */
 	for _, v := range m.mounts {

--- a/machine.go
+++ b/machine.go
@@ -996,7 +996,10 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 	for _, v := range m.mounts {
 		/* Check the directory exists on the host */
 		stat, err := os.Stat(v.hostDirectory)
-		if err != nil || !stat.IsDir() {
+		if err != nil {
+			return -1, fmt.Errorf("couldn't stat %s: %w", v.hostDirectory, err)
+		}
+		if !stat.IsDir() {
 			return -1, fmt.Errorf("couldn't mount %s inside machine: expected a directory", v.hostDirectory)
 		}
 

--- a/machine.go
+++ b/machine.go
@@ -22,10 +22,13 @@ import (
 	writerhelper "github.com/go-debos/fakemachine/cpio"
 )
 
-func mergedUsrSystem() bool {
-	f, _ := os.Lstat("/bin")
+func mergedUsrSystem() (bool, error) {
+	f, err := os.Lstat("/bin")
+	if err != nil {
+		return false, fmt.Errorf("failed to stat '/bin': %w", err)
+	}
 
-	return (f.Mode() & os.ModeSymlink) == os.ModeSymlink
+	return (f.Mode() & os.ModeSymlink) == os.ModeSymlink, nil
 }
 
 // Parse modinfo output and return the value of module attributes
@@ -126,7 +129,7 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 
 			// Ensure destination has /usr prefix if running
 			// on merged-usr system.
-			if mergedUsrSystem() && !strings.HasPrefix(dest, "/usr") {
+			if m.mergedUsr && !strings.HasPrefix(dest, "/usr") {
 				dest = "/usr" + dest
 			}
 
@@ -210,6 +213,7 @@ type Machine struct {
 	sectorSize int
 	showBoot   bool
 	quiet      bool
+	mergedUsr  bool
 	Environ    []string
 
 	scratchsize int64
@@ -242,7 +246,13 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	// usr is mounted by specific label via /init
 	m.addStaticVolume("/usr", "usr")
 
-	if !mergedUsrSystem() {
+	// check if the host is a merged-usr system
+	m.mergedUsr, err = mergedUsrSystem()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if the host is a merged-usr system: %w", err)
+	}
+
+	if !m.mergedUsr {
 		m.addStaticVolume("/sbin", "sbin")
 		m.addStaticVolume("/bin", "bin")
 		m.addStaticVolume("/lib", "lib")
@@ -740,7 +750,7 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr 
 		return fmt.Errorf("failed to write /var/run symlink: %w", err)
 	}
 
-	if mergedUsrSystem() {
+	if m.mergedUsr {
 		err = w.WriteSymlinks([]writerhelper.WriteSymlink{
 			{Target: "/usr/sbin", Link: "/sbin", Perm: 0755},
 			{Target: "/usr/bin", Link: "/bin", Perm: 0755},
@@ -762,7 +772,7 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr 
 	}
 
 	prefix := ""
-	if mergedUsrSystem() {
+	if m.mergedUsr {
 		prefix = "/usr"
 	}
 

--- a/machine.go
+++ b/machine.go
@@ -501,8 +501,7 @@ func (m *Machine) AddVolume(directory string) {
 //
 // The returned string is the device path of the new image as seen inside
 // fakemachine.
-func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (string,
-	error) {
+func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (_ string, err error) {
 	if size < 0 {
 		_, err := os.Stat(path)
 		if err != nil {
@@ -524,16 +523,18 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (s
 	if err != nil {
 		return "", fmt.Errorf("failed to create image file %s: %w", path, err)
 	}
+	defer func() {
+		if closeErr := i.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close image file %s: %w", path, closeErr))
+		}
+	}()
 
 	if size >= 0 {
-		err = i.Truncate(size)
-		if err != nil {
-			i.Close()
-			return "", fmt.Errorf("failed to truncate image file: %w", err)
+		if err := i.Truncate(size); err != nil {
+			return "", fmt.Errorf("failed to truncate image file %s: %w", path, err)
 		}
 	}
 
-	i.Close()
 	m.images = append(m.images, image{path, label})
 
 	return fmt.Sprintf("/dev/disk/by-fakemachine-label/%s", label), nil

--- a/machine.go
+++ b/machine.go
@@ -741,12 +741,17 @@ func (m *Machine) setupscratch() error {
 	return nil
 }
 
-func (m *Machine) cleanup() {
-	if m.scratchfile != "" {
-		os.Remove(m.scratchfile)
+func (m *Machine) cleanup() error {
+	if m.scratchfile == "" {
+		return nil
+	}
+
+	if err := os.Remove(m.scratchfile); err != nil {
+		return fmt.Errorf("failed to remove scratchfile %q: %w", m.scratchfile, err)
 	}
 
 	m.scratchfile = ""
+	return nil
 }
 
 func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr error) {

--- a/machine.go
+++ b/machine.go
@@ -1047,8 +1047,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 	}
 
 	success, err := m.backend.Start()
-	if !success || err != nil {
+	if err != nil {
 		return -1, fmt.Errorf("error starting %s backend: %w", m.backend.Name(), err)
+	}
+	if !success {
+		return -1, fmt.Errorf("error starting %s backend: unknown error", m.backend.Name())
 	}
 
 	result, err := os.Open(resultPath)

--- a/machine.go
+++ b/machine.go
@@ -592,11 +592,7 @@ func (m *Machine) SetQuiet(quiet bool) {
 // Path is "" then the working directory is used as a default storage location
 func (m *Machine) SetScratch(scratchsize int64, path string) {
 	m.scratchsize = scratchsize
-	if path == "" {
-		m.scratchpath, _ = os.Getwd()
-	} else {
-		m.scratchpath = path
-	}
+	m.scratchpath = path
 }
 
 func (m Machine) generateFstab(w *writerhelper.WriterHelper, backend backend) error {
@@ -712,6 +708,14 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper, moddir strin
 func (m *Machine) setupscratch() error {
 	if m.scratchsize == 0 {
 		return nil
+	}
+
+	if m.scratchpath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory for scratch path: %w", err)
+		}
+		m.scratchpath = cwd
 	}
 
 	tmpfile, err := os.CreateTemp(m.scratchpath, "fake-scratch.img.")

--- a/machine.go
+++ b/machine.go
@@ -724,7 +724,9 @@ func (m *Machine) setupscratch() error {
 		return fmt.Errorf("failed to create temp file for scratch: %w", err)
 	}
 	m.scratchfile = tmpfile.Name()
-	tmpfile.Close()
+	if err := tmpfile.Close(); err != nil {
+		return fmt.Errorf("failed to close scratch temp file: %w", err)
+	}
 
 	m.scratchdev, err = m.CreateImageWithLabel(m.scratchfile, m.scratchsize, "fake-scratch")
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -1058,7 +1058,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 	if err != nil {
 		return -1, fmt.Errorf("failed to open result file: %w", err)
 	}
-	defer result.Close()
+	defer func() {
+		if closeErr := result.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close result file: %w", closeErr))
+		}
+	}()
 
 	exitstr, err := io.ReadAll(result)
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -197,6 +197,21 @@ func (m *Machine) addVolumeIfExists(volumePath string) (bool, error) {
 	return true, nil
 }
 
+func (m *Machine) addVolumesWithGlob(pattern string) error {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("glob %s: %w", pattern, err)
+	}
+
+	for _, volumePath := range matches {
+		if _, err := m.addVolumeIfExists(volumePath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type Arch string
 
 const (
@@ -291,12 +306,8 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	}
 
 	// Mounts for java VM configuration, especially security policies
-	matches, _ := filepath.Glob("/etc/java*")
-	for _, path := range matches {
-		stat, err := os.Stat(path)
-		if err == nil && stat.IsDir() {
-			m.AddVolume(path)
-		}
+	if err := m.addVolumesWithGlob("/etc/java*"); err != nil {
+		return nil, err
 	}
 
 	// Dbus configuration

--- a/machine.go
+++ b/machine.go
@@ -754,14 +754,15 @@ func (m *Machine) cleanup() error {
 	return nil
 }
 
-func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr error) {
+func (m *Machine) buildInitrd(command string, extracontent [][2]string) (err error) {
 	f, err := os.OpenFile(m.initrdpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create initrd file: %w", err)
 	}
+
 	defer func() {
-		if cerr := f.Close(); cerr != nil && retErr == nil {
-			retErr = fmt.Errorf("failed to close initrd file: %w", cerr)
+		if closeErr := f.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close initrd file: %w", closeErr))
 		}
 	}()
 
@@ -772,8 +773,8 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr 
 
 	w := writerhelper.NewWriterHelper(f)
 	defer func() {
-		if cerr := w.Close(); cerr != nil && retErr == nil {
-			retErr = fmt.Errorf("failed to close cpio writer: %w", cerr)
+		if closeErr := w.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close cpio writer: %w", closeErr))
 		}
 	}()
 

--- a/machine.go
+++ b/machine.go
@@ -999,7 +999,9 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 		}
 	}()
 
-	os.Setenv("PATH", os.Getenv("PATH")+":/sbin:/usr/sbin")
+	if err := os.Setenv("PATH", os.Getenv("PATH")+":/sbin:/usr/sbin"); err != nil {
+		return -1, fmt.Errorf("failed to set PATH: %w", err)
+	}
 
 	/* Sanity check mountpoints */
 	for _, v := range m.mounts {

--- a/machine.go
+++ b/machine.go
@@ -765,14 +765,15 @@ func (m *Machine) cleanup() error {
 	return nil
 }
 
-func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr error) {
+func (m *Machine) buildInitrd(command string, extracontent [][2]string) (err error) {
 	f, err := os.OpenFile(m.initrdpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		return fmt.Errorf("failed to create initrd file: %w", err)
 	}
+
 	defer func() {
-		if cerr := f.Close(); cerr != nil && retErr == nil {
-			retErr = fmt.Errorf("failed to close initrd file: %w", cerr)
+		if closeErr := f.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close initrd file: %w", closeErr))
 		}
 	}()
 
@@ -783,8 +784,8 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr 
 
 	w := writerhelper.NewWriterHelper(f)
 	defer func() {
-		if cerr := w.Close(); cerr != nil && retErr == nil {
-			retErr = fmt.Errorf("failed to close cpio writer: %w", cerr)
+		if closeErr := w.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close cpio writer: %w", closeErr))
 		}
 	}()
 

--- a/machine.go
+++ b/machine.go
@@ -41,10 +41,20 @@ func getModData(modname string, fieldname string, kernelRelease string) ([]strin
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		field := strings.Split(strings.TrimSpace(scanner.Text()), ":")
-		if strings.TrimSpace(field[0]) == fieldname {
-			fieldValue = append(fieldValue, strings.TrimSpace(field[1]))
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
 		}
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, fmt.Errorf("unexpected modinfo output for module %q: %q", modname, line)
+		}
+		if strings.TrimSpace(name) == fieldname {
+			fieldValue = append(fieldValue, strings.TrimSpace(value))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan modinfo output for module %q: %w", modname, err)
 	}
 	return fieldValue, nil
 }

--- a/machine.go
+++ b/machine.go
@@ -735,7 +735,9 @@ func (m *Machine) setupscratch() error {
 		return fmt.Errorf("failed to create temp file for scratch: %w", err)
 	}
 	m.scratchfile = tmpfile.Name()
-	tmpfile.Close()
+	if err := tmpfile.Close(); err != nil {
+		return fmt.Errorf("failed to close scratch temp file: %w", err)
+	}
 
 	m.scratchdev, err = m.CreateImageWithLabel(m.scratchfile, m.scratchsize, "fake-scratch")
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -512,13 +512,6 @@ func (m *Machine) AddVolume(directory string) {
 // The returned string is the device path of the new image as seen inside
 // fakemachine.
 func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (_ string, err error) {
-	if size < 0 {
-		_, err := os.Stat(path)
-		if err != nil {
-			return "", fmt.Errorf("failed to stat image file %s: %w", path, err)
-		}
-	}
-
 	if len(label) >= 20 {
 		return "", fmt.Errorf("image label %q too long; cannot be more than 20 characters", label)
 	}
@@ -529,8 +522,16 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (_
 		}
 	}
 
-	i, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
+	flags := os.O_WRONLY
+	if size >= 0 {
+		flags |= os.O_CREATE
+	}
+
+	i, err := os.OpenFile(path, flags, 0666)
 	if err != nil {
+		if size < 0 {
+			return "", fmt.Errorf("failed to open existing image file %s: %w", path, err)
+		}
 		return "", fmt.Errorf("failed to create image file %s: %w", path, err)
 	}
 	defer func() {

--- a/machine.go
+++ b/machine.go
@@ -1030,7 +1030,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 		return -1, fmt.Errorf("failed to create temp directory: %w", err)
 	}
 	m.AddVolumeAt(tmpdir, "/run/fakemachine")
-	defer os.RemoveAll(tmpdir)
+	defer func() {
+		if removeErr := os.RemoveAll(tmpdir); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to remove tempdir %s: %w", tmpdir, removeErr))
+		}
+	}()
 
 	err = m.setupscratch()
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -511,8 +511,7 @@ func (m *Machine) AddVolume(directory string) {
 //
 // The returned string is the device path of the new image as seen inside
 // fakemachine.
-func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (string,
-	error) {
+func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (_ string, err error) {
 	if size < 0 {
 		_, err := os.Stat(path)
 		if err != nil {
@@ -534,16 +533,18 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (s
 	if err != nil {
 		return "", fmt.Errorf("failed to create image file %s: %w", path, err)
 	}
+	defer func() {
+		if closeErr := i.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close image file %s: %w", path, closeErr))
+		}
+	}()
 
 	if size >= 0 {
-		err = i.Truncate(size)
-		if err != nil {
-			i.Close()
-			return "", fmt.Errorf("failed to truncate image file: %w", err)
+		if err := i.Truncate(size); err != nil {
+			return "", fmt.Errorf("failed to truncate image file %s: %w", path, err)
 		}
 	}
 
-	i.Close()
 	m.images = append(m.images, image{path, label})
 
 	return fmt.Sprintf("/dev/disk/by-fakemachine-label/%s", label), nil

--- a/machine.go
+++ b/machine.go
@@ -22,10 +22,13 @@ import (
 	writerhelper "github.com/go-debos/fakemachine/cpio"
 )
 
-func mergedUsrSystem() bool {
-	f, _ := os.Lstat("/bin")
+func mergedUsrSystem() (bool, error) {
+	f, err := os.Lstat("/bin")
+	if err != nil {
+		return false, fmt.Errorf("failed to stat '/bin': %w", err)
+	}
 
-	return (f.Mode() & os.ModeSymlink) == os.ModeSymlink
+	return (f.Mode() & os.ModeSymlink) == os.ModeSymlink, nil
 }
 
 // Parse modinfo output and return the value of module attributes
@@ -136,7 +139,7 @@ func (m *Machine) copyModules(w *writerhelper.WriterHelper, modname string, copi
 
 			// Ensure destination has /usr prefix if running
 			// on merged-usr system.
-			if mergedUsrSystem() && !strings.HasPrefix(dest, "/usr") {
+			if m.mergedUsr && !strings.HasPrefix(dest, "/usr") {
 				dest = "/usr" + dest
 			}
 
@@ -220,6 +223,7 @@ type Machine struct {
 	sectorSize int
 	showBoot   bool
 	quiet      bool
+	mergedUsr  bool
 	Environ    []string
 
 	scratchsize int64
@@ -252,7 +256,13 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	// usr is mounted by specific label via /init
 	m.addStaticVolume("/usr", "usr")
 
-	if !mergedUsrSystem() {
+	// check if the host is a merged-usr system
+	m.mergedUsr, err = mergedUsrSystem()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if the host is a merged-usr system: %w", err)
+	}
+
+	if !m.mergedUsr {
 		m.addStaticVolume("/sbin", "sbin")
 		m.addStaticVolume("/bin", "bin")
 		m.addStaticVolume("/lib", "lib")
@@ -750,7 +760,7 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr 
 		return fmt.Errorf("failed to write /var/run symlink: %w", err)
 	}
 
-	if mergedUsrSystem() {
+	if m.mergedUsr {
 		err = w.WriteSymlinks([]writerhelper.WriteSymlink{
 			{Target: "/usr/sbin", Link: "/sbin", Perm: 0755},
 			{Target: "/usr/bin", Link: "/bin", Perm: 0755},
@@ -772,7 +782,7 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr 
 	}
 
 	prefix := ""
-	if mergedUsrSystem() {
+	if m.mergedUsr {
 		prefix = "/usr"
 	}
 

--- a/machine.go
+++ b/machine.go
@@ -1069,7 +1069,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 	if err != nil {
 		return -1, fmt.Errorf("failed to open result file: %w", err)
 	}
-	defer result.Close()
+	defer func() {
+		if closeErr := result.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("failed to close result file: %w", closeErr))
+		}
+	}()
 
 	exitstr, err := io.ReadAll(result)
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -752,12 +752,17 @@ func (m *Machine) setupscratch() error {
 	return nil
 }
 
-func (m *Machine) cleanup() {
-	if m.scratchfile != "" {
-		os.Remove(m.scratchfile)
+func (m *Machine) cleanup() error {
+	if m.scratchfile == "" {
+		return nil
+	}
+
+	if err := os.Remove(m.scratchfile); err != nil {
+		return fmt.Errorf("failed to remove scratchfile %q: %w", m.scratchfile, err)
 	}
 
 	m.scratchfile = ""
+	return nil
 }
 
 func (m *Machine) buildInitrd(command string, extracontent [][2]string) (retErr error) {

--- a/machine.go
+++ b/machine.go
@@ -1007,7 +1007,10 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 	for _, v := range m.mounts {
 		/* Check the directory exists on the host */
 		stat, err := os.Stat(v.hostDirectory)
-		if err != nil || !stat.IsDir() {
+		if err != nil {
+			return -1, fmt.Errorf("couldn't stat %s: %w", v.hostDirectory, err)
+		}
+		if !stat.IsDir() {
 			return -1, fmt.Errorf("couldn't mount %s inside machine: expected a directory", v.hostDirectory)
 		}
 

--- a/machine.go
+++ b/machine.go
@@ -1058,8 +1058,11 @@ func (m *Machine) startup(command string, extracontent [][2]string) (code int, e
 	}
 
 	success, err := m.backend.Start()
-	if !success || err != nil {
+	if err != nil {
 		return -1, fmt.Errorf("error starting %s backend: %w", m.backend.Name(), err)
+	}
+	if !success {
+		return -1, fmt.Errorf("error starting %s backend: unknown error", m.backend.Name())
 	}
 
 	result, err := os.Open(resultPath)

--- a/machine.go
+++ b/machine.go
@@ -602,11 +602,7 @@ func (m *Machine) SetQuiet(quiet bool) {
 // Path is "" then the working directory is used as a default storage location
 func (m *Machine) SetScratch(scratchsize int64, path string) {
 	m.scratchsize = scratchsize
-	if path == "" {
-		m.scratchpath, _ = os.Getwd()
-	} else {
-		m.scratchpath = path
-	}
+	m.scratchpath = path
 }
 
 func (m Machine) generateFstab(w *writerhelper.WriterHelper, backend backend) error {
@@ -722,6 +718,14 @@ func (m *Machine) writerKernelModules(w *writerhelper.WriterHelper, moddir strin
 func (m *Machine) setupscratch() error {
 	if m.scratchsize == 0 {
 		return nil
+	}
+
+	if m.scratchpath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory for scratch path: %w", err)
+		}
+		m.scratchpath = cwd
 	}
 
 	tmpfile, err := os.CreateTemp(m.scratchpath, "fake-scratch.img.")

--- a/machine.go
+++ b/machine.go
@@ -183,6 +183,30 @@ func realDir(path string) (string, error) {
 	return filepath.Dir(p), nil
 }
 
+// addVolumeIfExists adds volumePath as a machine volume if it exists on the host.
+//
+// It returns true if the volume was added. A missing path is not treated as an
+// error and returns false, nil. If the path exists but is not a directory, or
+// cannot be checked, it returns false and an error.
+func (m *Machine) addVolumeIfExists(volumePath string) (bool, error) {
+	stat, err := os.Stat(volumePath)
+
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to check %q: %w", volumePath, err)
+	}
+
+	if !stat.IsDir() {
+		return false, fmt.Errorf("failed to add volume %q: not a directory", volumePath)
+	}
+
+	m.AddVolume(volumePath)
+	return true, nil
+}
+
 type Arch string
 
 const (
@@ -269,11 +293,11 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	}
 
 	// Mounts for ssl certificates
-	if _, err := os.Stat("/etc/ca-certificates"); err == nil {
-		m.AddVolume("/etc/ca-certificates")
+	if _, err := m.addVolumeIfExists("/etc/ca-certificates"); err != nil {
+		return nil, err
 	}
-	if _, err := os.Stat("/etc/ssl"); err == nil {
-		m.AddVolume("/etc/ssl")
+	if _, err := m.addVolumeIfExists("/etc/ssl"); err != nil {
+		return nil, err
 	}
 
 	// Mounts for java VM configuration, especially security policies
@@ -286,17 +310,18 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	}
 
 	// Dbus configuration
-	if _, err := os.Stat("/etc/dbus-1"); err == nil {
-		m.AddVolume("/etc/dbus-1")
+	if _, err := m.addVolumeIfExists("/etc/dbus-1"); err != nil {
+		return nil, err
 	}
 
 	// Debian alternative symlinks
-	if _, err := os.Stat("/etc/alternatives"); err == nil {
-		m.AddVolume("/etc/alternatives")
+	if _, err := m.addVolumeIfExists("/etc/alternatives"); err != nil {
+		return nil, err
 	}
-	// Debians binfmt registry
-	if _, err := os.Stat("/var/lib/binfmts"); err == nil {
-		m.AddVolume("/var/lib/binfmts")
+
+	// Debian binfmt registry
+	if _, err := m.addVolumeIfExists("/var/lib/binfmts"); err != nil {
+		return nil, err
 	}
 
 	return m, nil

--- a/machine.go
+++ b/machine.go
@@ -207,6 +207,21 @@ func (m *Machine) addVolumeIfExists(volumePath string) (bool, error) {
 	return true, nil
 }
 
+func (m *Machine) addVolumesWithGlob(pattern string) error {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("glob %s: %w", pattern, err)
+	}
+
+	for _, volumePath := range matches {
+		if _, err := m.addVolumeIfExists(volumePath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type Arch string
 
 const (
@@ -301,12 +316,8 @@ func NewMachineWithBackend(backendName string) (*Machine, error) {
 	}
 
 	// Mounts for java VM configuration, especially security policies
-	matches, _ := filepath.Glob("/etc/java*")
-	for _, path := range matches {
-		stat, err := os.Stat(path)
-		if err == nil && stat.IsDir() {
-			m.AddVolume(path)
-		}
+	if err := m.addVolumesWithGlob("/etc/java*"); err != nil {
+		return nil, err
 	}
 
 	// Dbus configuration

--- a/machine.go
+++ b/machine.go
@@ -992,8 +992,12 @@ func (m *Machine) buildInitrd(command string, extracontent [][2]string) (err err
 
 // Start the machine running the given command and adding the extra content to
 // the cpio. Extracontent is a list of {source, dest} tuples
-func (m *Machine) startup(command string, extracontent [][2]string) (int, error) {
-	defer m.cleanup()
+func (m *Machine) startup(command string, extracontent [][2]string) (code int, err error) {
+	defer func() {
+		if cleanupErr := m.cleanup(); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("cleanup failed: %w", cleanupErr))
+		}
+	}()
 
 	os.Setenv("PATH", os.Getenv("PATH")+":/sbin:/usr/sbin")
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -57,48 +57,43 @@ func TestImage(t *testing.T) {
 	require.Equal(t, 0, exitcode)
 }
 
-func AssertDevSectorSize(t *testing.T, device string, sectorsize int) {
-	bstypes := []string{"physical", "logical"}
-	for _, bstype := range bstypes {
-		path := "/sys/block/" + device + "/queue/" + bstype + "_block_size"
-		f, err := os.Open(path)
-		require.NoError(t, err)
-		defer f.Close()
-
-		blkdev := bufio.NewReader(f)
-		line, err := blkdev.ReadString('\n')
-		require.NoError(t, err)
-
-		line = strings.TrimSuffix(line, "\n")
-		sz, err := strconv.Atoi(line)
-		require.NoError(t, err)
-
-		require.Equal(t, sectorsize, sz)
-	}
-}
-
 func AssertSectorSize(t *testing.T, sectorsize int) {
-	if !InMachine() {
-		t.Parallel()
-		m := CreateMachine(t)
-		m.SetSectorSize(sectorsize)
-		_, err := m.CreateImage("test-"+strconv.Itoa(sectorsize)+"-sector-size.img", 1024*1024)
-		require.NoError(t, err)
-		switch sectorsize {
-		case 512:
-			exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestImage512SectorSize", backendName})
+	t.Helper()
+	t.Parallel()
+	if InMachine() {
+		for _, bstype := range []string{"physical", "logical"} {
+			device := "vda"
+			path := "/sys/block/" + device + "/queue/" + bstype + "_block_size"
+
+			data, err := os.ReadFile(path)
 			require.NoError(t, err)
-			require.Equal(t, 0, exitcode)
-		case 4096:
-			exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestImage4kSectorSize", backendName})
+
+			sz, err := strconv.Atoi(strings.TrimSpace(string(data)))
 			require.NoError(t, err)
-			require.Equal(t, 0, exitcode)
-		default:
-			t.Fatalf("Unhandled sector size %d", sectorsize)
+
+			require.Equal(t, sectorsize, sz)
 		}
-	} else {
-		AssertDevSectorSize(t, "vda", sectorsize)
+		return
 	}
+
+	m := CreateMachine(t)
+	m.SetSectorSize(sectorsize)
+	_, err := m.CreateImage("test-"+strconv.Itoa(sectorsize)+"-sector-size.img", 1024*1024)
+	require.NoError(t, err)
+
+	testName := ""
+	switch sectorsize {
+	case 512:
+		testName = "TestImage512SectorSize"
+	case 4096:
+		testName = "TestImage4kSectorSize"
+	default:
+		t.Fatalf("Unhandled sector size %d", sectorsize)
+	}
+
+	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", testName, backendName})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitcode)
 }
 
 func TestImage512SectorSize(t *testing.T) {

--- a/machine_test.go
+++ b/machine_test.go
@@ -264,9 +264,7 @@ func TestDiskSuffix(t *testing.T) {
 		{52, "ba"}, {701, "zz"}, {702, "aaa"},
 	}
 	for _, c := range cases {
-		if got := diskSuffix(c.i); got != c.want {
-			t.Errorf("diskSuffix(%d) = %q, want %q", c.i, got, c.want)
-		}
+		require.Equal(t, c.want, diskSuffix(c.i), "diskSuffix(%d)", c.i)
 	}
 }
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -22,7 +22,7 @@ func init() {
 
 func CreateMachine(t *testing.T) *Machine {
 	machine, err := NewMachineWithBackend(backendName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	machine.SetNumCPUs(2)
 
 	return machine
@@ -54,7 +54,7 @@ func TestImage(t *testing.T) {
 	m := CreateMachine(t)
 
 	_, err := m.CreateImage("test.img", 1024*1024)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	exitcode, _ := m.Run("test -b /dev/disk/by-fakemachine-label/fakedisk-0")
 
 	if exitcode != 0 {
@@ -67,16 +67,16 @@ func AssertDevSectorSize(t *testing.T, device string, sectorsize int) {
 	for _, bstype := range bstypes {
 		path := "/sys/block/" + device + "/queue/" + bstype + "_block_size"
 		f, err := os.Open(path)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer f.Close()
 
 		blkdev := bufio.NewReader(f)
 		line, err := blkdev.ReadString('\n')
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		line = strings.TrimSuffix(line, "\n")
 		sz, err := strconv.Atoi(line)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, sectorsize, sz)
 	}
@@ -88,7 +88,7 @@ func AssertSectorSize(t *testing.T, sectorsize int) {
 		m := CreateMachine(t)
 		m.SetSectorSize(sectorsize)
 		_, err := m.CreateImage("test-"+strconv.Itoa(sectorsize)+"-sector-size.img", 1024*1024)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		switch sectorsize {
 		case 512:
 			exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImage512SectorSize", backendName})
@@ -114,7 +114,7 @@ func TestImage4kSectorSize(t *testing.T) {
 
 func AssertMount(t *testing.T, mountpoint, fstype string) {
 	m, err := os.Open("/proc/self/mounts")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	mtab := bufio.NewReader(m)
 
@@ -124,7 +124,7 @@ func AssertMount(t *testing.T, mountpoint, fstype string) {
 			require.Fail(t, "mountpoint not found")
 			break
 		}
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		fields := strings.Fields(line)
 		if fields[1] == mountpoint {
@@ -216,11 +216,11 @@ func TestImageLabel(t *testing.T) {
 		labeled := devices[1]
 
 		info, err := os.Stat(autolabel)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, os.ModeDevice, info.Mode()&os.ModeType, "Expected a device")
 
 		info, err = os.Stat(labeled)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, os.ModeDevice, info.Mode()&os.ModeType, "Expected a device")
 
 		return
@@ -228,10 +228,10 @@ func TestImageLabel(t *testing.T) {
 
 	m := CreateMachine(t)
 	autolabel, err := m.CreateImage("test-autolabel.img", 1024*1024)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	labeled, err := m.CreateImageWithLabel("test-labeled.img", 1024*1024, "test-labeled")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImageLabel", autolabel, labeled})
 	if exitcode != 0 {

--- a/machine_test.go
+++ b/machine_test.go
@@ -92,10 +92,10 @@ func AssertSectorSize(t *testing.T, sectorsize int) {
 		switch sectorsize {
 		case 512:
 			exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImage512SectorSize", backendName})
-			require.Equal(t, exitcode, 0)
+			require.Equal(t, 0, exitcode)
 		case 4096:
 			exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImage4kSectorSize", backendName})
-			require.Equal(t, exitcode, 0)
+			require.Equal(t, 0, exitcode)
 		default:
 			t.Fatalf("Unhandled sector size %d", sectorsize)
 		}
@@ -128,7 +128,7 @@ func AssertMount(t *testing.T, mountpoint, fstype string) {
 
 		fields := strings.Fields(line)
 		if fields[1] == mountpoint {
-			require.Equal(t, fields[2], fstype)
+			require.Equal(t, fstype, fields[2])
 			return
 		}
 	}
@@ -210,18 +210,18 @@ func TestImageLabel(t *testing.T) {
 	if InMachine() {
 		t.Log("Running in the machine")
 		devices := flag.Args()
-		require.Equal(t, len(devices), 2, "Only expected two devices")
+		require.Equal(t, 2, len(devices), "Only expected two devices")
 
 		autolabel := devices[0]
 		labeled := devices[1]
 
 		info, err := os.Stat(autolabel)
 		require.Nil(t, err)
-		require.Equal(t, info.Mode()&os.ModeType, os.ModeDevice, "Expected a device")
+		require.Equal(t, os.ModeDevice, info.Mode()&os.ModeType, "Expected a device")
 
 		info, err = os.Stat(labeled)
 		require.Nil(t, err)
-		require.Equal(t, info.Mode()&os.ModeType, os.ModeDevice, "Expected a device")
+		require.Equal(t, os.ModeDevice, info.Mode()&os.ModeType, "Expected a device")
 
 		return
 	}
@@ -251,7 +251,7 @@ func TestVolumes(t *testing.T) {
 	m.AddVolume("random_directory_never_exists")
 
 	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestVolumes"})
-	require.Equal(t, exitcode, -1)
+	require.Equal(t, -1, exitcode)
 	require.Error(t, err)
 
 	/* Try to mount a device file into the machine */
@@ -259,7 +259,7 @@ func TestVolumes(t *testing.T) {
 	m.AddVolume("/dev/zero")
 
 	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run", "TestVolumes"})
-	require.Equal(t, exitcode, -1)
+	require.Equal(t, -1, exitcode)
 	require.Error(t, err)
 
 	/* Try to mount a volume with whitespace into the machine */
@@ -267,7 +267,7 @@ func TestVolumes(t *testing.T) {
 	m.AddVolumeAt("/dev", "/dev ices")
 
 	exitcode, err = m.RunInMachineWithArgs([]string{"-test.run", "TestVolumes"})
-	require.Equal(t, exitcode, -1)
+	require.Equal(t, -1, exitcode)
 	require.Error(t, err)
 }
 
@@ -301,7 +301,7 @@ func TestCommandEscaping(t *testing.T) {
 	t.Parallel()
 	if InMachine() {
 		t.Log("Running in the machine")
-		require.Equal(t, testArg, "$s'n\\akes")
+		require.Equal(t, "$s'n\\akes", testArg)
 		t.Log(testArg)
 		return
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -32,7 +32,8 @@ func TestSuccessfulCommand(t *testing.T) {
 	t.Parallel()
 	m := CreateMachine(t)
 
-	exitcode, _ := m.Run("ls /")
+	exitcode, err := m.Run("ls /")
+	require.NoError(t, err)
 
 	if exitcode != 0 {
 		t.Fatalf("Expected 0 but got %d", exitcode)
@@ -42,7 +43,8 @@ func TestSuccessfulCommand(t *testing.T) {
 func TestCommandNotFound(t *testing.T) {
 	t.Parallel()
 	m := CreateMachine(t)
-	exitcode, _ := m.Run("/a/b/c /")
+	exitcode, err := m.Run("/a/b/c /")
+	require.NoError(t, err)
 
 	if exitcode != 127 {
 		t.Fatalf("Expected 127 but got %d", exitcode)
@@ -55,7 +57,8 @@ func TestImage(t *testing.T) {
 
 	_, err := m.CreateImage("test.img", 1024*1024)
 	require.NoError(t, err)
-	exitcode, _ := m.Run("test -b /dev/disk/by-fakemachine-label/fakedisk-0")
+	exitcode, err := m.Run("test -b /dev/disk/by-fakemachine-label/fakedisk-0")
+	require.NoError(t, err)
 
 	if exitcode != 0 {
 		t.Fatalf("Test for the virtual image device failed with %d", exitcode)
@@ -91,10 +94,12 @@ func AssertSectorSize(t *testing.T, sectorsize int) {
 		require.NoError(t, err)
 		switch sectorsize {
 		case 512:
-			exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImage512SectorSize", backendName})
+			exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestImage512SectorSize", backendName})
+			require.NoError(t, err)
 			require.Equal(t, 0, exitcode)
 		case 4096:
-			exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImage4kSectorSize", backendName})
+			exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestImage4kSectorSize", backendName})
+			require.NoError(t, err)
 			require.Equal(t, 0, exitcode)
 		default:
 			t.Fatalf("Unhandled sector size %d", sectorsize)
@@ -143,7 +148,8 @@ func TestScratchTmp(t *testing.T) {
 
 	m := CreateMachine(t)
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchTmp"})
+	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchTmp"})
+	require.NoError(t, err)
 
 	if exitcode != 0 {
 		t.Fatalf("Test for tmpfs mount on scratch failed with %d", exitcode)
@@ -160,7 +166,8 @@ func TestScratchDisk(t *testing.T) {
 	m := CreateMachine(t)
 	m.SetScratch(1024*1024*1024, "")
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchDisk"})
+	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchDisk"})
+	require.NoError(t, err)
 
 	if exitcode != 0 {
 		t.Fatalf("Test for device mount on scratch failed with %d", exitcode)
@@ -182,7 +189,8 @@ if [ ${MEM} -lt 900000 -o ${MEM} -gt 1024000 ] ; then
   exit 1
 fi
 `
-	exitcode, _ := m.Run(command)
+	exitcode, err := m.Run(command)
+	require.NoError(t, err)
 
 	if exitcode != 0 {
 		t.Fatalf("Test for set memory failed with %d", exitcode)
@@ -198,7 +206,8 @@ func TestSpawnMachine(t *testing.T) {
 
 	m := CreateMachine(t)
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestSpawnMachine"})
+	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestSpawnMachine"})
+	require.NoError(t, err)
 
 	if exitcode != 0 {
 		t.Fatalf("Test for respawning in the machine failed failed with %d", exitcode)
@@ -233,7 +242,8 @@ func TestImageLabel(t *testing.T) {
 	labeled, err := m.CreateImageWithLabel("test-labeled.img", 1024*1024, "test-labeled")
 	require.NoError(t, err)
 
-	exitcode, _ := m.RunInMachineWithArgs([]string{"-test.run", "TestImageLabel", autolabel, labeled})
+	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestImageLabel", autolabel, labeled})
+	require.NoError(t, err)
 	if exitcode != 0 {
 		t.Fatalf("Test for images in the machine failed failed with %d", exitcode)
 	}
@@ -307,9 +317,10 @@ func TestCommandEscaping(t *testing.T) {
 	}
 
 	m := CreateMachine(t)
-	exitcode, _ := m.RunInMachineWithArgs([]string{
+	exitcode, err := m.RunInMachineWithArgs([]string{
 		"-test.v", "-test.run",
 		"TestCommandEscaping", "-testarg", "$s'n\\akes"})
+	require.NoError(t, err)
 
 	if exitcode != 0 {
 		t.Fatalf("Expected 0 but got %d", exitcode)

--- a/machine_test.go
+++ b/machine_test.go
@@ -34,21 +34,16 @@ func TestSuccessfulCommand(t *testing.T) {
 
 	exitcode, err := m.Run("ls /")
 	require.NoError(t, err)
-
-	if exitcode != 0 {
-		t.Fatalf("Expected 0 but got %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }
 
 func TestCommandNotFound(t *testing.T) {
 	t.Parallel()
 	m := CreateMachine(t)
+
 	exitcode, err := m.Run("/a/b/c /")
 	require.NoError(t, err)
-
-	if exitcode != 127 {
-		t.Fatalf("Expected 127 but got %d", exitcode)
-	}
+	require.Equal(t, 127, exitcode)
 }
 
 func TestImage(t *testing.T) {
@@ -59,10 +54,7 @@ func TestImage(t *testing.T) {
 	require.NoError(t, err)
 	exitcode, err := m.Run("test -b /dev/disk/by-fakemachine-label/fakedisk-0")
 	require.NoError(t, err)
-
-	if exitcode != 0 {
-		t.Fatalf("Test for the virtual image device failed with %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }
 
 func AssertDevSectorSize(t *testing.T, device string, sectorsize int) {
@@ -150,10 +142,7 @@ func TestScratchTmp(t *testing.T) {
 
 	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchTmp"})
 	require.NoError(t, err)
-
-	if exitcode != 0 {
-		t.Fatalf("Test for tmpfs mount on scratch failed with %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }
 
 func TestScratchDisk(t *testing.T) {
@@ -168,10 +157,7 @@ func TestScratchDisk(t *testing.T) {
 
 	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestScratchDisk"})
 	require.NoError(t, err)
-
-	if exitcode != 0 {
-		t.Fatalf("Test for device mount on scratch failed with %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }
 
 func TestMemory(t *testing.T) {
@@ -191,10 +177,7 @@ fi
 `
 	exitcode, err := m.Run(command)
 	require.NoError(t, err)
-
-	if exitcode != 0 {
-		t.Fatalf("Test for set memory failed with %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }
 
 func TestSpawnMachine(t *testing.T) {
@@ -208,10 +191,7 @@ func TestSpawnMachine(t *testing.T) {
 
 	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestSpawnMachine"})
 	require.NoError(t, err)
-
-	if exitcode != 0 {
-		t.Fatalf("Test for respawning in the machine failed failed with %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }
 
 func TestImageLabel(t *testing.T) {
@@ -244,9 +224,7 @@ func TestImageLabel(t *testing.T) {
 
 	exitcode, err := m.RunInMachineWithArgs([]string{"-test.run", "TestImageLabel", autolabel, labeled})
 	require.NoError(t, err)
-	if exitcode != 0 {
-		t.Fatalf("Test for images in the machine failed failed with %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }
 
 func TestVolumes(t *testing.T) {
@@ -321,8 +299,5 @@ func TestCommandEscaping(t *testing.T) {
 		"-test.v", "-test.run",
 		"TestCommandEscaping", "-testarg", "$s'n\\akes"})
 	require.NoError(t, err)
-
-	if exitcode != 0 {
-		t.Fatalf("Expected 0 but got %d", exitcode)
-	}
+	require.Equal(t, 0, exitcode)
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -107,6 +107,9 @@ func TestImage4kSectorSize(t *testing.T) {
 func AssertMount(t *testing.T, mountpoint, fstype string) {
 	m, err := os.Open("/proc/self/mounts")
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, m.Close())
+	}()
 
 	mtab := bufio.NewReader(m)
 


### PR DESCRIPTION
This PR improves error handling throughout fakemachine and enables the
`errcheck` linter to help prevent ignored errors from being reintroduced.

The main goal is to stop silently discarding errors from filesystem operations,
process setup, decompression, cleanup paths and backend probing.

Where cleanup or close operations can fail after another error has already occurred, the
errors are preserved with `errors.Join`.