### PR TITLE
Improve fakemachine memory parsing and CPU help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Application Options:
   -v, --volume=                 volume to mount
   -i, --image=                  image to add
   -e, --environ-var=            Environment variables (use -e VARIABLE:VALUE syntax)
-  -m, --memory=                 Amount of memory for the fakemachine in megabytes
-  -c, --cpus=                   Number of CPUs for the fakemachine
+  -m, --memory=                 Amount of memory for the fakemachine (parsed with human-readable suffix; assumed bytes if no suffix) (default: 2Gb)
+  -c, --cpus=                   Number of CPUs for the fakemachine (defaults to number of CPUs on the host)
   -S, --sectorsize=             Override image sector size
   -s, --scratchsize=            On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used
       --show-boot               Show boot/console messages from the fakemachine

--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -20,7 +20,7 @@ type Options struct {
 	Images      []string          `short:"i" long:"image" description:"image to add"`
 	EnvironVars map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
 	Memory      string            `short:"m" long:"memory" description:"Amount of memory for the fakemachine (parsed with human-readable suffix; assumed bytes if no suffix)" default:"2Gb"`
-	CPUs        int               `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine"`
+	CPUs        int               `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine (defaults to number of CPUs on the host)"`
 	SectorSize  int               `short:"S" long:"sectorsize" description:"Override image sector size"`
 	ScratchSize string            `short:"s" long:"scratchsize" description:"On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used"`
 	ShowBoot    bool              `long:"show-boot" description:"Show boot/console messages from the fakemachine"`

--- a/cmd/fakemachine/main.go
+++ b/cmd/fakemachine/main.go
@@ -19,7 +19,7 @@ type Options struct {
 	Volumes     []string          `short:"v" long:"volume" description:"volume to mount"`
 	Images      []string          `short:"i" long:"image" description:"image to add"`
 	EnvironVars map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
-	Memory      int               `short:"m" long:"memory" description:"Amount of memory for the fakemachine in megabytes"`
+	Memory      string            `short:"m" long:"memory" description:"Amount of memory for the fakemachine (parsed with human-readable suffix; assumed bytes if no suffix)" default:"2Gb"`
 	CPUs        int               `short:"c" long:"cpus" description:"Number of CPUs for the fakemachine"`
 	SectorSize  int               `short:"S" long:"sectorsize" description:"Override image sector size"`
 	ScratchSize string            `short:"s" long:"scratchsize" description:"On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used"`
@@ -221,9 +221,17 @@ func main() {
 		m.SetScratch(size, "")
 	}
 
-	if options.Memory > 0 {
-		m.SetMemory(options.Memory)
+	// Parse memory
+	memsize, err := units.RAMInBytes(options.Memory)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fakemachine: Couldn't parse --memory %q: %v\n", options.Memory, err)
+		os.Exit(1)
 	}
+	memsizeMB := int(memsize / 1024 / 1024)
+	if memsizeMB < 256 {
+		fmt.Printf("WARNING: Memory size of %dMB is less than recommended minimum 256MB\n", memsizeMB)
+	}
+	m.SetMemory(memsizeMB)
 
 	if options.CPUs > 0 {
 		m.SetNumCPUs(options.CPUs)

--- a/doc/man/fakemachine.1
+++ b/doc/man/fakemachine.1
@@ -19,8 +19,8 @@ Application Options:
   \-v, \-\-volume=                 volume to mount
   \-i, \-\-image=                  image to add
   \-e, \-\-environ\-var=            Environment variables (use \-e VARIABLE:VALUE syntax)
-  \-m, \-\-memory=                 Amount of memory for the fakemachine in megabytes
-  \-c, \-\-cpus=                   Number of CPUs for the fakemachine
+  \-m, \-\-memory=                 Amount of memory for the fakemachine (parsed with human\-readable suffix; assumed bytes if no suffix) (default: 2Gb)
+  \-c, \-\-cpus=                   Number of CPUs for the fakemachine (defaults to number of CPUs on the host)
   \-S, \-\-sectorsize=             Override image sector size
   \-s, \-\-scratchsize=            On\-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used
       \-\-show\-boot               Show boot/console messages from the fakemachine

--- a/doc/man/fakemachine.md
+++ b/doc/man/fakemachine.md
@@ -20,8 +20,8 @@ Application Options:
   -v, --volume=                 volume to mount
   -i, --image=                  image to add
   -e, --environ-var=            Environment variables (use -e VARIABLE:VALUE syntax)
-  -m, --memory=                 Amount of memory for the fakemachine in megabytes
-  -c, --cpus=                   Number of CPUs for the fakemachine
+  -m, --memory=                 Amount of memory for the fakemachine (parsed with human-readable suffix; assumed bytes if no suffix) (default: 2Gb)
+  -c, --cpus=                   Number of CPUs for the fakemachine (defaults to number of CPUs on the host)
   -S, --sectorsize=             Override image sector size
   -s, --scratchsize=            On-disk scratch space size (with a unit suffix, e.g. 4G); if unset, memory backed scratch space is used
       --show-boot               Show boot/console messages from the fakemachine


### PR DESCRIPTION
Allow --memory to accept human-readable size suffixes instead of only integer megabyte values. This matches the behaviour of other size options and makes values such as 512M, 2G or 2Gb usable directly. This also matches the syntax used in debos and keeps syntax parity.

The parsed value is converted to megabytes before being passed to the machine configuration. Values without a suffix are interpreted as bytes by the parser and invalid values produce an error message.

Set the default memory value to 2Gb and warn when the configured memory is below the recommended minimum of 256MB (the same as used in debos).


Also Update the --cpus help text to explain that fakemachine defaults to
using the number of CPUs available on the host when no explicit value
is provided.
