### PR TITLE
Make sure to create image file from scratch

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -522,7 +522,7 @@ func (m *Machine) CreateImageWithLabel(path string, size int64, label string) (_
 		}
 	}
 
-	flags := os.O_WRONLY
+	flags := os.O_WRONLY | os.O_TRUNC
 	if size >= 0 {
 		flags |= os.O_CREATE
 	}


### PR DESCRIPTION
Truncate to 0 while opening the file, otherwise when the image file already exists, old data will remain, making bmaptool inefficient. Beside of that it's a potential info leak.