### PR TITLE
ci: avoid pushing container images from PR workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,8 @@ jobs:
       uses: docker/build-push-action@v7
       with:
         context: .
-        push: true
+        # PR workflows do not have permission to publish GHCR images
+        push: ${{ github.event_name != 'pull_request' }}
         pull: true
         file: Dockerfile
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Pull request workflows may not have permission to write to the organisation's container registry (e.g. when triggered from forks or by users who are not members of the organisation).

Only push container images for non-PR events while still allowing PRs to build the image.