### PR TITLE
test: check existing image is not truncated when size is -1

### DIFF
--- a/machine_test.go
+++ b/machine_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -269,6 +270,25 @@ func TestImageLabelUniqueness(t *testing.T) {
 
 	_, err = m.CreateImageWithLabel("test2.img", 1024*1024, "my-disk")
 	require.Error(t, err)
+}
+
+func TestImageExistingNotTruncated(t *testing.T) {
+	m := CreateMachine(t)
+
+	path := filepath.Join(t.TempDir(), "existing.img")
+
+	// Populate image with data
+	content := []byte("this data must be preserved")
+	require.NoError(t, os.WriteFile(path, content, 0666))
+
+	// With size == -1 the image should already exist and its contents must not
+	// be modified
+	_, err := m.CreateImageWithLabel(path, -1, "existing")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, got, "existing image contents must not be truncated")
 }
 
 func TestCommandEscaping(t *testing.T) {


### PR DESCRIPTION
Depends on #320 

CreateImageWithLabel states that when size is -1 the image should already exist and its size (and contents) are not modified. PR #313 regressed this by always opening the file with os.O_TRUNC, wiping any existing data; this slipped through as nothing exercised the size == -1 path with a pre-populated image.

Add a test that writes known content to an image file and verifies it is preserved after CreateImageWithLabel(path, -1, ...), guarding the documented contract against future regressions.