### PR TITLE
ci: use rolling test-container names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/${{matrix.os}}:main
+      image: ghcr.io/go-debos/test-containers/${{matrix.os}}:wip-obbardc-small-cleanups
       options: >-
         --security-opt label=disable
         --cap-add=SYS_PTRACE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
         # See https://github.com/actions/runner-images/issues/183
         os:
           - arch
-          - debian-trixie
-          - debian-forky
-          - ubuntu-questing
+          - debian-stable
+          - debian-testing
+          - ubuntu-devel
           - fedora-latest
         backend:
           - qemu


### PR DESCRIPTION
The test-containers repository has switched from codename-specific image names to rolling aliases which track the current release, so the CI matrix no longer needs updating each time a distro release moves on.

Map the images accordingly:

  debian-trixie   -> debian-stable
  debian-forky    -> debian-testing
  ubuntu-questing -> ubuntu-devel

See https://github.com/go-debos/test-containers/pull/67